### PR TITLE
Create screenshots folder if it doesn't exist

### DIFF
--- a/platforms/windows/AppPlatform_windows.cpp
+++ b/platforms/windows/AppPlatform_windows.cpp
@@ -12,6 +12,8 @@
 #include "thirdparty/stb_image.h"
 #include "thirdparty/stb_image_write.h"
 
+#include <shlobj.h>
+
 extern LPCTSTR g_GameTitle;
 
 void AppPlatform_windows::initConsts()
@@ -39,7 +41,38 @@ void AppPlatform_windows::saveScreenshot(const std::string& fileName, int width,
 	glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 
 	stbi_flip_vertically_on_write(true);
-	stbi_write_png(fileName.c_str(), width, height, 4, pixels, width * 4);
+
+	// Verify if the folder exists for saving screenshots and
+	// create it if it doesn't 
+	// Kinda inefficient but I didn't want to be too intrusive 
+	// -Vruk
+	// https://stackoverflow.com/a/22182041
+
+	// https://stackoverflow.com/a/8901001
+	CHAR mypicturespath[MAX_PATH];
+	HRESULT result = SHGetFolderPath(NULL, CSIDL_MYPICTURES, NULL, SHGFP_TYPE_CURRENT, mypicturespath);
+
+	static char str[MAX_PATH];
+
+	if (result == S_OK)
+		sprintf(str, "%s\\%s", mypicturespath, "MCPE");
+	else
+		sprintf(str, "%s\\%s", ".", "Screenshots");
+
+	// https://stackoverflow.com/a/8233867
+	DWORD ftyp = GetFileAttributesA(str);
+
+	DWORD error = GetLastError();
+	if (error == ERROR_PATH_NOT_FOUND || error == ERROR_FILE_NOT_FOUND || error == ERROR_INVALID_NAME)
+	{
+		// https://stackoverflow.com/a/22182041
+		CreateDirectory(str, NULL);
+	}
+	
+	char fullpath[MAX_PATH];
+	sprintf(fullpath, "%s\\%s", str, fileName.c_str());
+
+	stbi_write_png(fullpath, width, height, 4, pixels, width * 4);
 
 	delete[] pixels;
 }

--- a/platforms/windows/main.cpp
+++ b/platforms/windows/main.cpp
@@ -231,7 +231,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLin
 
 	g_pApp = new NinecraftApp;
 	g_pApp->m_pPlatform = &g_AppPlatform;
-	g_pApp->field_D58 = ".";
+	g_pApp->m_externalStorageDir = ".";
 
 	// initialize the app
 	g_pApp->init();

--- a/source/App/Minecraft.hpp
+++ b/source/App/Minecraft.hpp
@@ -109,7 +109,7 @@ public:
 	bool m_bGrabbedMouse = true;
 	HitResult m_hitResult;
 	int m_progressPercent = 0;
-	std::string field_D58;
+	std::string m_externalStorageDir;
 	Timer m_timer;
 	bool m_bPreparingLevel = false;
 	LevelStorageSource* m_pLevelStorageSource = nullptr; // TODO

--- a/source/World/Renderer/LevelRenderer.cpp
+++ b/source/World/Renderer/LevelRenderer.cpp
@@ -1031,9 +1031,9 @@ void LevelRenderer::takePicture(TripodCamera* pCamera, Entity* pOwner)
 	static char str[256];
 	// @HUH: This has the potential to overwrite a file
 #ifdef ORIGINAL_CODE
-	sprintf(str, "%s/games/com.mojang/img_%.4d.jpg", m_pMinecraft->field_D58.c_str(), getTimeMs());
+	sprintf(str, "%s/games/com.mojang/img_%.4d.jpg", m_pMinecraft->m_externalStorageDir.c_str(), getTimeMs());
 #else
-	sprintf(str, "%s/games/com.mojang/img_%.4d.png", m_pMinecraft->field_D58.c_str(), getTimeMs());
+	sprintf(str, "img_%.4d.png", getTimeMs());
 #endif
 
 	m_pMinecraft->platform()->saveScreenshot(std::string(str), Minecraft::width, Minecraft::height);


### PR DESCRIPTION
When taking a screenshot the windows implementation will now check for a folder to save to and create it if it does not exist

g_pApp->field_D58 is now g_pApp->m_externalStorageDir