### PR TITLE
Surround tickMouse() call in ORIGINAL_CODE preprocessor check

### DIFF
--- a/source/App/Minecraft.cpp
+++ b/source/App/Minecraft.cpp
@@ -566,7 +566,9 @@ void Minecraft::update()
 		m_pLevel->updateLights();
 	}
 
+#ifndef ORIGINAL_CODE
 	tickMouse();
+#endif
 
 	m_pGameRenderer->render(m_timer.field_18);
 }


### PR DESCRIPTION
The call to `tickMouse()` in `Minecraft.cpp` seems to be missing a preprocessor check for `ORIGINAL_CODE`. Despite the fact that this definition doesn't still work yet, this will save some headaches later :)