### PR TITLE
Fix options.txt overriding in-game changed settings at runtime

### DIFF
--- a/source/GUI/Screen/OptionsScreen.cpp
+++ b/source/GUI/Screen/OptionsScreen.cpp
@@ -145,7 +145,9 @@ void OptionsScreen::render(int a, int b, float c)
 
 void OptionsScreen::removed()
 {
+#ifdef ORIGINAL_CODE // Reloading options will reload the options.txt we introduced. Don't do this
 	m_pMinecraft->reloadOptions();
+#endif
 }
 
 #ifndef ORIGINAL_CODE


### PR DESCRIPTION
With the introduction of the `options.txt` support for Windows platforms, changing an option in the options menu while in-game would get overridden each time by the value set in the options.txt file.

![](https://i.imgur.com/hFhVndJ.gif)

This PR adds an overloaded method to `Platform` that accepts a `bool` indicating whether or not the options file should be read. This is then called in `OptionsScreen#remove()` which is responsible for updating the in-game options. Other calls to `getOptionStrings()` remain untouched as `true` is the default value.