### PR TITLE
Proper input normalization code

### DIFF
--- a/source/World/Entity/Entity.cpp
+++ b/source/World/Entity/Entity.cpp
@@ -484,8 +484,10 @@ void Entity::absMoveTo(float x, float y, float z, float yaw, float pitch)
 	return setRot(yaw, pitch);
 }
 
+// Y is some sort of scalar value, not related to the position you're moving to
 void Entity::moveRelative(float x, float z, float y)
 {
+#ifdef ORIGINAL_CODE
 	float d = sqrtf(x * x + z * z);
 	if (d < 0.01f) return;
 	if (d > 1.0f)
@@ -494,6 +496,22 @@ void Entity::moveRelative(float x, float z, float y)
 	y /= d;
 	x *= y;
 	z *= y;
+#else
+	// length of input vector
+	float d = sqrtf((x * x) + (z * z));
+	if (d < 0.01f) return;
+
+	// normalization factor
+	float factor = 1.0f / d;
+
+	// cap length
+	if (d > 1.0f)
+		d = 1.0f;
+
+	// apply factor * length
+	x *= factor * d * y;
+	z *= factor * d * y;
+#endif
 
 	float yaw = m_yaw * float(M_PI);
 	float syaw = sinf(yaw / 180.0f);


### PR DESCRIPTION
Walking diagonally with keyboard input causes the player to move twice as fast, and enabling sneak doesn't limit your walking speed.
The change I have created uses correct input normalization code that preserves the length of the input vector, so gamepad controls can be finer and sneak speed is preserved, while limiting the walking speed with multiple directions pressed.
If you want to test this with sneaking, add "m_keyBinds[9].value = AKEYCODE_SHIFT_LEFT;" to "Options::initDefaultValues()" to bind it to left shift.