### PR TITLE
Platform Definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -378,3 +378,6 @@ FodyWeavers.xsd
 
 /windows_vs/games/com.mojang
 /windows_vs/assets
+/mcpe01_canada
+/thirdparty/OpenAL
+/mcpe01_canada.apk

--- a/platforms/Platform_Definitions.hpp
+++ b/platforms/Platform_Definitions.hpp
@@ -1,0 +1,12 @@
+#include <SoundSystem.hpp>
+
+//				Sound Systems
+//-----------------------------------------
+
+// Windows Sound System (Direct Sound)
+#if 1
+	#include "windows/SoundSystem_windows.hpp"
+	#define SOUND_SYSTEM_TYPE SoundSystemWindows
+#endif
+
+//-----------------------------------------

--- a/source/Sound/SoundEngine.hpp
+++ b/source/Sound/SoundEngine.hpp
@@ -15,12 +15,13 @@
 
 // Platform specific type for the sound system.
 
-#ifdef _WIN32
-#include "../../platforms/windows/SoundSystem_windows.hpp"
-#define SOUND_SYSTEM_TYPE SoundSystemWindows
-#else
+#ifdef ORIGINAL_CODE
 #define SOUND_SYSTEM_TYPE SoundSystem
+#else
+#include "..\..\platforms\Platform_Definitions.hpp"
 #endif
+
+
 
 //#define SOUND_SYSTEM_TYPE SoundSystemSL
 


### PR DESCRIPTION
Made a platform definitions header file for any sort of platform dependant code switching needed.

Made the Sound Engine use the sound system defined in the platform definitions file.