### PR TITLE
Add ENH_3D_INVENTORY_TILES

### DIFF
--- a/GameMods.hpp
+++ b/GameMods.hpp
@@ -28,6 +28,7 @@
 #define ENH_USE_GUI_SCALE_2     // Use a 2x GUI scale instead of 3x. Looks better on PC
 #define ENH_ALLOW_SCROLL_WHEEL  // Allow use of the scroll wheel to change selected inventory slots
 #define ENH_DISABLE_TURN_ACCEL  // Disable the turn acceleration mechanism. It should only be used on Xperia Play
+#define ENH_3D_INVENTORY_TILES  // Uses 3D rendered inventory tiles, use with ENH_SHADE_HELD_TILES to render correctly.
 
 // Mods
 //#define MOD_USE_FLAT_WORLD         // Use a flat world instead of the regular world generation

--- a/source/World/Renderer/ItemRenderer.cpp
+++ b/source/World/Renderer/ItemRenderer.cpp
@@ -84,6 +84,7 @@ void ItemRenderer::render(Entity* pEntity, float x, float y, float z, float a, f
 			#	define PARM_HACK
 			#endif
 			tileRenderer->renderTile(Tile::tiles[itemID], pItemInstance->m_auxValue PARM_HACK);
+			#undef PARM_HACK
 			glPopMatrix();
 		}
 	}
@@ -177,13 +178,23 @@ void ItemRenderer::renderGuiItem(Font* font, Textures* textures, ItemInstance* i
 
 		bool bCanRenderAsIs = false;
 
-		if (COND_PRE (TileRenderer::canRender(Tile::tiles[itemID]->getRenderShape()) || g_ItemFrames[itemID] != 0))
+#ifdef ENH_3D_INVENTORY_TILES
+		// We don't need to care about g_ItemFrames at all since blocks will get 3D rendered and 2D props will use the terrain.png as the texture.
+		if (COND_PRE(TileRenderer::canRender(Tile::tiles[itemID]->getRenderShape())))
 		{
 			bCanRenderAsIs = true;
 		}
+#else
+		if (COND_PRE(TileRenderer::canRender(Tile::tiles[itemID]->getRenderShape()) || g_ItemFrames[itemID] != 0))
+		{
+			bCanRenderAsIs = true;
+		}
+#endif
+		
 
 		if (itemID < C_MAX_TILES && bCanRenderAsIs)
 		{
+#ifndef ENH_3D_INVENTORY_TILES
 			textures->loadAndBindTexture(C_BLOCKS_NAME);
 
 			float texU = float(g_ItemFrames[instance->m_itemID] % 10) * 48.0f;
@@ -197,6 +208,33 @@ void ItemRenderer::renderGuiItem(Font* font, Textures* textures, ItemInstance* i
 			t.vertexUV(float(x + 16), float(y +  0), 0.0f, (texU + 48.0f) / 512.0f,  texV          / 512.0f);
 			t.vertexUV(float(x +  0), float(y +  0), 0.0f,  texU          / 512.0f,  texV          / 512.0f);
 			t.draw();
+#else
+			textures->loadAndBindTexture(C_TERRAIN_NAME);
+
+			//glDisable(GL_BLEND);
+			//glEnable(GL_DEPTH_TEST);
+
+			glPushMatrix();
+
+			// scale, rotate, and translate the tile onto the correct screen coordinate
+			glTranslatef((GLfloat)x + 8, (GLfloat)y + 8, -8);
+			glScalef(10, 10, 10);
+			glRotatef(210.0f, 1.0f, 0.0f, 0.0f);
+			glRotatef(45.0f, 0.0f, 1.0f, 0.0f);
+
+			#ifdef ENH_SHADE_HELD_TILES
+			#	define PARM_HACK , 1
+			#else
+			#	define PARM_HACK
+			#endif
+			tileRenderer->renderTile(Tile::tiles[itemID], instance->m_auxValue PARM_HACK);
+			#undef PARM_HACK
+
+			glPopMatrix();
+
+			//glDisable(GL_DEPTH_TEST);
+			//glEnable(GL_BLEND);
+#endif
 		}
 		else if (instance->getIcon() >= 0)
 		{

--- a/source/World/Renderer/TileRenderer.cpp
+++ b/source/World/Renderer/TileRenderer.cpp
@@ -2308,10 +2308,10 @@ void TileRenderer::renderTile(Tile* tile, int data RENDER_TILE_ARG_PATCH)
 		renderFaceUp  (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_YNEG, data));
 		SHADE_IF_NEEDED(1.0f);
 		renderFaceDown(tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_YPOS, data));
-		SHADE_IF_NEEDED(0.8f);
+		SHADE_IF_NEEDED(0.6f);
 		renderNorth   (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_ZNEG, data));
 		renderSouth   (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_ZPOS, data));
-		SHADE_IF_NEEDED(0.6f);
+		SHADE_IF_NEEDED(0.8f);
 		renderWest    (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_XNEG, data));
 		renderEast    (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_XPOS, data));
 		SHADE_IF_NEEDED(1.0f);
@@ -2368,10 +2368,10 @@ void TileRenderer::renderTile(Tile* tile, int data RENDER_TILE_ARG_PATCH)
 			renderFaceUp  (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_YNEG, data));
 			SHADE_IF_NEEDED(1.0f);
 			renderFaceDown(tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_YPOS, data));
-			SHADE_IF_NEEDED(0.8f);
+			SHADE_IF_NEEDED(0.6f);
 			renderNorth   (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_ZNEG, data));
 			renderSouth   (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_ZPOS, data));
-			SHADE_IF_NEEDED(0.6f);
+			SHADE_IF_NEEDED(0.8f);
 			renderWest    (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_XNEG, data));
 			renderEast    (tile, 0.0f, 0.0f, 0.0f, tile->getTexture(DIR_XPOS, data));
 			SHADE_IF_NEEDED(1.0f);


### PR DESCRIPTION
Removes the need to use and update gui_blocks.png for adding new blocks, and allows block items to scale better in the menu.
Stairs currently have a rendering issue reminiscent of Minecraft Alpha.

Also rotates the ENH_SHADE_HELD_TILES shading to be more accurate to the original gui_blocks.png atlas icons.