### PR TITLE
Improve and fix crash in SoundSystemWindows

### DIFF
--- a/platforms/windows/SoundSystem_windows.hpp
+++ b/platforms/windows/SoundSystem_windows.hpp
@@ -30,16 +30,16 @@ public:
 	~SoundSystemWindows();
 	virtual bool isAvailable();
 	virtual void setListenerPos(float x, float y, float z);
-	virtual void setListenerAngle(float f);
+	virtual void setListenerAngle(float yaw, float pitch);
 	virtual void load(const std::string& sound);
 	virtual void play(const std::string& sound);
 	virtual void pause(const std::string& sound);
 	virtual void stop(const std::string& sound);
 	virtual void playAt(const SoundDesc& sound, float x, float y, float z, float a, float b);
 private:
+	bool m_available = false;
 	IDirectSound8* m_directsound;
 	IDirectSoundBuffer* m_primarybuffer;
-
+	LPDIRECTSOUND3DLISTENER8* m_listener;
 	std::vector<LPDIRECTSOUNDBUFFER*> m_buffers;
 };
-

--- a/source/App/Minecraft.cpp
+++ b/source/App/Minecraft.cpp
@@ -527,6 +527,15 @@ void Minecraft::tick()
 		{
 			m_pTextures->tick();
 			m_pParticleEngine->tick();
+
+#ifndef ORIGINAL_CODE
+			if (m_pMobPersp)
+			{
+				m_pSoundEngine->m_soundSystem.setListenerPos(m_pMobPersp->m_pos.x, m_pMobPersp->m_pos.y, m_pMobPersp->m_pos.z);
+				m_pSoundEngine->m_soundSystem.setListenerAngle(m_pMobPersp->m_yaw, m_pMobPersp->m_pitch);
+			}
+#endif
+
 		}
 
 		if (field_D14)

--- a/source/Sound/SoundSystem.cpp
+++ b/source/Sound/SoundSystem.cpp
@@ -17,9 +17,15 @@ void SoundSystem::setListenerPos(float x, float y, float z)
 {
 }
 
-void SoundSystem::setListenerAngle(float f)
+#ifndef ORIGINAL_CODE
+void SoundSystem::setListenerAngle(float yaw, float pitch)
 {
 }
+#else
+void SoundSystem::setListenerAngle(float yaw)
+{
+}
+#endif
 
 void SoundSystem::load(const std::string& sound)
 {

--- a/source/Sound/SoundSystem.hpp
+++ b/source/Sound/SoundSystem.hpp
@@ -16,7 +16,11 @@ class SoundSystem
 public:
 	virtual bool isAvailable();
 	virtual void setListenerPos(float x, float y, float z);
-	virtual void setListenerAngle(float f);
+#ifndef ORIGINAL_CODE
+	virtual void setListenerAngle(float yaw, float pitch);
+#else
+	virtual void setListenerAngle(float yaw);
+#endif
 	virtual void load(const std::string& sound);
 	virtual void play(const std::string& sound);
 	virtual void pause(const std::string& sound);


### PR DESCRIPTION
Add 3D Sound Listener, Fix crash when DirectSound fails to initialize. Add second argument to setListenerAngle. Implement setListenerAngle and setListenerPos in Minecraft.cpp (Is this a good place to put it?)