### PR TITLE
Fixed rendering bugs & crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -385,3 +385,4 @@ FodyWeavers.xsd
 /assets/
 /options.txt
 /windows_vs/options.txt
+/games/com.mojang/minecraftWorlds

--- a/.gitignore
+++ b/.gitignore
@@ -383,6 +383,6 @@ FodyWeavers.xsd
 /wasm
 
 /assets/
+/games/
 /options.txt
 /windows_vs/options.txt
-/games/com.mojang/minecraftWorlds

--- a/source/Minecraft.cpp
+++ b/source/Minecraft.cpp
@@ -251,7 +251,7 @@ label_3:
 
 			ItemInstance* pItem = getSelectedItem();
 
-			if (m_pGameMode->useItemOn(m_pLocalPlayer, m_pLevel, pItem->m_itemID < 0 ? nullptr : pItem, hr.m_tileX, hr.m_tileY, hr.m_tileZ, hr.m_hitSide))
+			if (m_pGameMode->useItemOn(m_pLocalPlayer, m_pLevel, pItem->m_itemID <= 0 ? nullptr : pItem, hr.m_tileX, hr.m_tileY, hr.m_tileZ, hr.m_hitSide))
 			{
 				m_pLocalPlayer->swing();
 				if (!isOnline())
@@ -301,7 +301,7 @@ label_3:
 		{
 		label_15:
 			int id = m_pLocalPlayer->m_pInventory->getSelectedItemId();
-			if (id >= 0)
+			if (id > 0)
 			{
 				ItemInstance* pItem = getSelectedItem();
 

--- a/source/client/model/Cube.cpp
+++ b/source/client/model/Cube.cpp
@@ -86,9 +86,9 @@ void Cube::compile(float f)
 void Cube::draw()
 {
 #ifdef ENH_ENTITY_SHADING
-	drawArrayVTC(m_buffer, 36, sizeof(Tesselator::Vertex));
-#else
 	drawArrayVT(m_buffer, 36, sizeof(Tesselator::Vertex));
+#else
+	drawArrayVTC(m_buffer, 36, sizeof(Tesselator::Vertex));
 #endif
 }
 

--- a/source/client/renderer/entity/HumanoidMobRenderer.cpp
+++ b/source/client/renderer/entity/HumanoidMobRenderer.cpp
@@ -24,7 +24,7 @@ void HumanoidMobRenderer::additionalRendering(Mob* mob, float f)
 	Player* player = (Player*)mob;
 
 	int itemID = player->m_pInventory->getSelectedItemId();
-	if (itemID < 0)
+	if (itemID <= 0)
 		return;
 
 	ItemInstance inst(itemID, 1, 0);

--- a/source/client/renderer/entity/TripodCameraRenderer.cpp
+++ b/source/client/renderer/entity/TripodCameraRenderer.cpp
@@ -60,7 +60,7 @@ void TripodCameraRenderer::render(Entity* entity, float x, float y, float z, flo
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		// @TODO FIX: With ENH_ENTITY_SHADING on, the cube is fully opaque.
 		glColor4f(0.5f, 0.5f, 0.5f, 0.5f);
-		m_cube.renderHorrible(0.0625f);
+		m_cube.render(0.0625f);
 		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 		glDisable(GL_BLEND);
 		glEnable(GL_TEXTURE_2D);


### PR DESCRIPTION
* Fixed shading of cubes (includes Steve & Camera head)
* Fixed crash from rendering of Air item in hand
* Fixed crash from right-clicking with Air item in-hand
* TripodCameraRenderer no longer uses Cube::renderHorrible