### PR TITLE
Fixed incorrect Entity push velocity direction

### DIFF
--- a/source/world/entity/Entity.cpp
+++ b/source/world/entity/Entity.cpp
@@ -863,9 +863,10 @@ void Entity::push(Entity* bud)
 		x2 = 1.0f;
 	float x3 = 1.0f - this->field_B0;
 	float x4 = x3 * diffX / x1 * x2 * 0.05f;
+	float x5 = x3 * diffZ / x1 * x2 * 0.05f;
 
-	push(-x4, 0.0f, -x4);
-	bud->push(x4, 0.0f, x4);
+	push(-x4, 0.0f, -x5);
+	bud->push(x4, 0.0f, x5);
 }
 
 void Entity::push(float x, float y, float z)


### PR DESCRIPTION
When I was trying multiplayer out with two instances, I noticed that the push directions between the two players weren't correct. The Z axis wasn't being used for the push function that adds on the velocity. I've fixed this below while also making sure that the bug itself wasn't an actual bug in mcpe 0.1.0 by looking at the disassembly from the apk.