### PR TITLE
Fix incorrect axes being used for clip min/max

### DIFF
--- a/source/client/common/AABB.cpp
+++ b/source/client/common/AABB.cpp
@@ -31,10 +31,10 @@ HitResult AABB::clip(const Vec3& vec1, const Vec3& vec2)
 
 	bClipMinX = vec1.clipX(vec2, min.x, clipMinX);
 	bClipMaxX = vec1.clipX(vec2, max.x, clipMaxX);
-	bClipMinY = vec1.clipX(vec2, min.y, clipMinY);
-	bClipMaxY = vec1.clipX(vec2, max.y, clipMaxY);
-	bClipMinZ = vec1.clipX(vec2, min.z, clipMinZ);
-	bClipMaxZ = vec1.clipX(vec2, max.z, clipMaxZ);
+	bClipMinY = vec1.clipY(vec2, min.y, clipMinY);
+	bClipMaxY = vec1.clipY(vec2, max.y, clipMaxY);
+	bClipMinZ = vec1.clipZ(vec2, min.z, clipMinZ);
+	bClipMaxZ = vec1.clipZ(vec2, max.z, clipMaxZ);
 
 	// <sigh>
 	if (bClipMinX)


### PR DESCRIPTION
I've noticed that sometimes the pick hit result would go through entities on certain axes except X. After some investigation and debugging, I've fixed the issue. It seems like this was caused by an error in decompilation, similar to my other issue (#42) from examining the code from the apk.