### PR TITLE
Fix held item not always being changed to the new held item

### DIFF
--- a/source/client/network/ClientSideNetworkHandler.cpp
+++ b/source/client/network/ClientSideNetworkHandler.cpp
@@ -353,7 +353,6 @@ void ClientSideNetworkHandler::handle(const RakNet::RakNetGUID& rakGuid, PlayerE
 	}
 
 	pPlayer->m_pInventory->selectItemById(pPlayerEquipmentPkt->m_itemID);
-	pPlayer->m_pInventory->selectSlot(0);
 }
 
 bool ClientSideNetworkHandler::areAllChunksLoaded()

--- a/source/client/network/ServerSideNetworkHandler.cpp
+++ b/source/client/network/ServerSideNetworkHandler.cpp
@@ -279,7 +279,6 @@ void ServerSideNetworkHandler::handle(const RakNet::RakNetGUID& guid, PlayerEqui
 	}
 
 	pPlayer->m_pInventory->selectItemById(packet->m_itemID);
-	pPlayer->m_pInventory->selectSlot(0);
 
 	redistributePacket(packet, guid);
 }


### PR DESCRIPTION
`pPlayer->m_pInventory->selectSlot(0);` overwrites the selected slot that is changed inside `pPlayer->m_pInventory->selectItemById`.