### PR TITLE
Fixed double destroy sounds/particles

### DIFF
--- a/source/world/gamemode/CreativeMode.cpp
+++ b/source/world/gamemode/CreativeMode.cpp
@@ -29,7 +29,10 @@ void CreativeMode::startDestroyBlock(int x, int y, int z, int i)
 		return;
 
 	if (m_pMinecraft->m_pLocalPlayer->canDestroy(Tile::tiles[tile]))
+	{
+		field_24 = 5;
 		destroyBlock(x, y, z, i);
+	}
 
 	return;
 }


### PR DESCRIPTION
I decided to fix it in the creative gamemode specifically to reduce impact on other gamemodes but the `Minecraft::handleMouseClick` and `Minecraft::handleMouseDown` might still need a fix for `field_DA4` in the future, not sure.

This code might slow down the speed at which blocks are destroyed when holding down the mouse button but only because the game was trying to destroy blocks like.. twice per tick before?