### PR TITLE
Fix MCPE Not Covering Screen Edges

### DIFF
--- a/source/client/renderer/GameRenderer.cpp
+++ b/source/client/renderer/GameRenderer.cpp
@@ -205,12 +205,12 @@ void GameRenderer::saveMatrices()
 
 void GameRenderer::setupGuiScreen()
 {
-	float x = Gui::InvGuiScale * Minecraft::width;
-	float y = Gui::InvGuiScale * Minecraft::height;
+	int x = (int) (Gui::InvGuiScale * Minecraft::width);
+	int y = (int) (Gui::InvGuiScale * Minecraft::height);
 	glClear(GL_ACCUM);
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
-	xglOrthof(0, x, y, 0, 2000.0f, 3000.0f);
+	xglOrthof(0, (float) x, (float) y, 0, 2000.0f, 3000.0f);
 	glMatrixMode(GL_MODELVIEW);
 	glLoadIdentity();
 	glTranslatef(0.0f, 0.0f, -2000.0f);


### PR DESCRIPTION
This fixes an issue where MCPE doesn't cover all of the screen's edges.

| Before | After |
| --- | --- |
| ![Screenshot from 2023-11-03 00-06-52](https://github.com/ReMinecraftPE/mcpe/assets/17478432/6c29b177-b25d-485d-9159-32eda8ad7909) | ![Screenshot from 2023-11-03 00-09-07](https://github.com/ReMinecraftPE/mcpe/assets/17478432/8df60d2a-545c-4ec1-b0b7-63b4501a2b86) |