### PR TITLE
SDL Center grabbed mouse & implement patch data

### DIFF
--- a/platforms/sdl/base/AppPlatform_sdl_base.cpp
+++ b/platforms/sdl/base/AppPlatform_sdl_base.cpp
@@ -26,6 +26,8 @@ void AppPlatform_sdl_base::_init(std::string storageDir, SDL_Window *window)
 	m_bShiftPressed[0] = false;
 	m_bShiftPressed[1] = false;
 
+	_mousegrabbed = false;
+
 	ensureDirectoryExists(_storageDir.c_str());
 
 	m_pLogger = new Logger;
@@ -156,6 +158,7 @@ int AppPlatform_sdl_base::getScreenHeight() const
 
 void AppPlatform_sdl_base::setMouseGrabbed(bool b)
 {
+	_mousegrabbed = b;
 	SDL_SetWindowGrab(_window, b ? SDL_TRUE : SDL_FALSE);
 	SDL_SetRelativeMouseMode(b ? SDL_TRUE : SDL_FALSE);
 }
@@ -164,6 +167,15 @@ void AppPlatform_sdl_base::setMouseDiff(int x, int y)
 {
 	xrel = x;
 	yrel = y;
+
+	// Keep the mouse centered if its grabbed
+	if (_mousegrabbed)
+	{
+		int w = 0, h = 0;
+		SDL_GetWindowSize(_window,&w,&h);
+		SDL_WarpMouseInWindow(_window,w/2,h/2);
+		Mouse::feed(MouseButtonType::BUTTON_NONE, false, w/2,h/2);
+	}
 }
 
 void AppPlatform_sdl_base::getMouseDiff(int& x, int& y)

--- a/platforms/sdl/base/AppPlatform_sdl_base.hpp
+++ b/platforms/sdl/base/AppPlatform_sdl_base.hpp
@@ -62,6 +62,8 @@ private:
 	int xrel;
 	int yrel;
 
+	bool _mousegrabbed;
+
 	Logger* m_pLogger;
 	SoundSystem* m_pSoundSystem;
 

--- a/platforms/sdl/desktop/AppPlatform_sdl.cpp
+++ b/platforms/sdl/desktop/AppPlatform_sdl.cpp
@@ -197,3 +197,15 @@ bool AppPlatform_sdl::hasFileSystemAccess()
 {
 	return true;
 }
+
+std::string AppPlatform_sdl::getPatchData()
+{
+	std::ifstream ifs("assets/patches/patch_data.txt");
+	if (!ifs.is_open())
+		return "";
+
+	std::stringstream ss;
+	ss << ifs.rdbuf();
+
+	return ss.str();
+}

--- a/platforms/sdl/desktop/AppPlatform_sdl.hpp
+++ b/platforms/sdl/desktop/AppPlatform_sdl.hpp
@@ -18,7 +18,8 @@ public:
 	bool doesTextureExist(const std::string& path) override;
 	
 	bool hasFileSystemAccess() override;
-	
+	std::string getPatchData() override;
+
 protected:
 	void ensureDirectoryExists(const char* path) override;
 };


### PR DESCRIPTION
SDL didn't center grabbed mouse so it would always select random stuff in the hotbar. Added patch_data reading for the firework :-)