### PR TITLE
Generate Missing Texture Texture

### DIFF
--- a/source/client/renderer/Textures.cpp
+++ b/source/client/renderer/Textures.cpp
@@ -19,9 +19,19 @@ int Textures::loadTexture(const std::string& name, bool bIsRequired)
 
 	Texture t = m_pPlatform->loadTexture(name, bIsRequired);
 
-	int result = -1;
-	if (t.m_pixels)
-		result = assignTexture(name, t);
+	if (!t.m_pixels) {
+		t.field_C = 1;
+		t.field_D = 0;
+		t.m_width = 2;
+		t.m_height = 2;
+		t.m_pixels = new uint32_t[4];
+		t.m_pixels[0] = 0xfff800f8;
+		t.m_pixels[1] = 0xff000000;
+		t.m_pixels[3] = 0xfff800f8;
+		t.m_pixels[2] = 0xff000000;
+	}
+
+	int result = assignTexture(name, t);
 
 	return result;
 }


### PR DESCRIPTION
This generates a proper "missing texture" texture when one fails to load.

IMO this is way better than everything just defaulting to **black**. (Seriously, if you don't have assets loaded, the entire title-screen will be 100% black and it isn't that clear what the error is.)

This will also stop ReMCPE from spamming the console with error messages when it can't find a texture. (This issue was caused by it trying to load the texture every frame, but now it will only try to load it once.)

Screenshot:
![Screenshot from 2024-01-23 22-18-53](https://github.com/ReMinecraftPE/mcpe/assets/17478432/e77d0002-8f6d-462e-9929-4adb22d6ecfa)