### PR TITLE
Several fixes and improvements...

### DIFF
--- a/source/client/app/Minecraft.cpp
+++ b/source/client/app/Minecraft.cpp
@@ -1163,6 +1163,8 @@ int Minecraft::getFpsIntlCounter()
 
 void Minecraft::leaveGame(bool bCopyMap)
 {
+	Keyboard::setBlocked(true);
+
 	m_bPreparingLevel = false;
 	m_pRakNetInstance->disconnect();
 	m_pMobPersp = nullptr;

--- a/source/client/gui/screens/StartMenuScreen.cpp
+++ b/source/client/gui/screens/StartMenuScreen.cpp
@@ -365,7 +365,7 @@ StartMenuScreen::StartMenuScreen() :
 
 StartMenuScreen::~StartMenuScreen()
 {
-	SAFE_DELETE(m_pTiles);
+	SAFE_DELETE_ARRAY(m_pTiles);
 }
 
 void StartMenuScreen::_updateLicense()

--- a/source/client/player/input/Keyboard.cpp
+++ b/source/client/player/input/Keyboard.cpp
@@ -13,6 +13,7 @@
 std::vector<KeyboardAction> Keyboard::_inputs;
 int Keyboard::_index = -1;
 Keyboard::KeyState Keyboard::_states[KEYBOARD_STATES_SIZE];
+bool Keyboard::_blocked = false;
 
 void Keyboard::feed(KeyState state, int key)
 {
@@ -30,7 +31,7 @@ void Keyboard::feed(KeyState state, int key)
 
 bool Keyboard::next()
 {
-	if (_index + 1 >= _inputs.size())
+	if (_blocked || _index + 1 >= _inputs.size())
 		return false;
 
 	_index++;
@@ -49,7 +50,7 @@ int Keyboard::getEventKeyState()
 
 bool Keyboard::isKeyDown(int keyCode)
 {
-	if (keyCode < 0 || keyCode >= KEYBOARD_STATES_SIZE)
+	if (_blocked || keyCode < 0 || keyCode >= KEYBOARD_STATES_SIZE)
 		return false;
 
 	return _states[keyCode] == DOWN;
@@ -59,4 +60,10 @@ void Keyboard::reset()
 {
 	_inputs.clear();
 	_index = -1;
+	_blocked = false;
+}
+
+void Keyboard::setBlocked(bool b)
+{
+	_blocked = b;
 }

--- a/source/client/player/input/Keyboard.hpp
+++ b/source/client/player/input/Keyboard.hpp
@@ -33,11 +33,13 @@ public:
 	static int  getEventKeyState();
 	static bool isKeyDown(int keyCode);
 	static void reset();
+	static void setBlocked(bool b);
 
 private:
 	static std::vector<KeyboardAction> _inputs;
 	static Keyboard::KeyState _states[KEYBOARD_STATES_SIZE];
 	static int _index;
+	static bool _blocked;
 };
 
 struct KeyboardAction

--- a/source/client/renderer/FireTexture.cpp
+++ b/source/client/renderer/FireTexture.cpp
@@ -13,14 +13,14 @@
 
 FireTexture::FireTexture(int a2) : DynamicTexture(Tile::fire->m_TextureFrame + 16 * a2)
 {
-	m_data1 = new float[320];
-	m_data2 = new float[320];
+    m_data1 = new float[320]();
+    m_data2 = new float[320]();
 }
 
 FireTexture::~FireTexture()
 {
-	SAFE_DELETE(m_data1);
-	SAFE_DELETE(m_data2);
+	SAFE_DELETE_ARRAY(m_data1);
+	SAFE_DELETE_ARRAY(m_data2);
 }
 
 void FireTexture::tick()

--- a/source/client/renderer/Font.cpp
+++ b/source/client/renderer/Font.cpp
@@ -39,7 +39,13 @@ void Font::init(Options* pOpts)
 			for (int j = 7; j >= 0; j--) // x position
 			{
 				int x = (i % 16), y = (i / 16);
-				int pixelDataIndex = pTexture->m_width * 8 * y + 8 * x + j;
+				uint32_t pixelDataIndex = uint32_t(pTexture->m_width * 8 * y + 8 * x + j);
+
+				if (pixelDataIndex >= (pTexture->m_width * pTexture->m_height))
+				{
+					LOG_E("Error could not initialize Font at %s, bad pixel data index.", m_fileName.c_str());
+					return;
+				}
 
 				for (int k = 0; k < 8; k++)
 				{


### PR DESCRIPTION
* Added ability to arbritrarily block/unblock keyboard input at any time, fixes a 'white screen' issue when pressing ESC right at the time where the save screen is shown - on Linux this even segfaults for some reason, haven't investigated root cause but this definitely seems to reliably stop it from happening on a higher level.

* Usage of SAFE_DELETE when SAFE_DELETE_ARRAY should be used for the sake of correctness

* Zero-init float arrays in FireTexture constructors

* Fix OOB read during Font::init when initializing a Font that may not exist or has corrupted data (both VS-ASan and Dr.Memory complained about it)