### PR TITLE
Player Reach Bugfixes

### DIFF
--- a/source/client/renderer/GameRenderer.cpp
+++ b/source/client/renderer/GameRenderer.cpp
@@ -30,7 +30,7 @@ void GameRenderer::_init()
 
 	field_8 = 0.0f;
 	field_C = 0;
-	field_10 = nullptr;
+	m_pHovered = nullptr;
 	field_14 = 0.0f;
 	field_18 = 0.0f;
 	field_1C = 0.0f;
@@ -980,7 +980,7 @@ void GameRenderer::pick(float f)
 
 	Mob* pMob = m_pMinecraft->m_pMobPersp;
 	HitResult& mchr = m_pMinecraft->m_hitResult;
-	float dist = m_pMinecraft->m_pGameMode->getPickRange();
+	float dist = m_pMinecraft->m_pGameMode->getBlockReachDistance();
 	bool isFirstPerson = !m_pMinecraft->getOptions()->m_bThirdPerson;
 
 	if (!m_pMinecraft->useSplitControls())
@@ -1065,19 +1065,20 @@ void GameRenderer::pick(float f)
 
 	Vec3 mobPos = pMob->getPos(f);
 
-	if (m_pMinecraft->m_hitResult.m_hitType != HitResult::NONE)
+	if (mchr.m_hitType != HitResult::NONE)
 		dist = mchr.m_hitPos.distanceTo(mobPos);
 
-	if (m_pMinecraft->m_pGameMode->isCreativeType())
+	float maxEntityDist = m_pMinecraft->m_pGameMode->getEntityReachDistance();
+	/*if (m_pMinecraft->m_pGameMode->isCreativeType())
 		dist = 7.0f;
-	else if (dist > 3.0f)
-		dist = 3.0f;
+	else */if (dist > maxEntityDist)
+		dist = maxEntityDist;
 
 	Vec3 view = pMob->getViewVector(f);
 	Vec3 exp  = view * dist;
 	Vec3 limit = mobPos + view * dist;
 
-	field_10 = nullptr;
+	m_pHovered = nullptr;
 
 	AABB scanAABB = pMob->m_hitbox;
 
@@ -1109,7 +1110,7 @@ void GameRenderer::pick(float f)
 			if (fDist >= 0.0f)
 			{
 				//this is it brother
-				field_10 = pEnt;
+				m_pHovered = pEnt;
 				fDist = 0.0f;
 			}
 			continue;
@@ -1124,20 +1125,20 @@ void GameRenderer::pick(float f)
 
 			if (fDist > fNewDist || fDist == 0.0f)
 			{
-				field_10 = pEnt;
+				m_pHovered = pEnt;
 				fDist = fNewDist;
 			}
 		}
 	}
 
 	// picked entities take priority over tiles (?!)
-	if (field_10)
+	if (m_pHovered)
 	{
-		m_pMinecraft->m_hitResult = HitResult(field_10);
+		mchr = HitResult(m_pHovered);
 		return;
 	}
 
-	if (m_pMinecraft->m_hitResult.m_hitType != HitResult::NONE || view.y >= -0.7f)
+	if (mchr.m_hitType != HitResult::NONE || view.y >= -0.7f)
 		return;
 
 	mobPos = pMob->getPos(f);
@@ -1154,11 +1155,11 @@ void GameRenderer::pick(float f)
 
 	if (fabsf(view.x) <= fabsf(view.z))
 	{
-		m_pMinecraft->m_hitResult.m_hitSide = view.z >= 0.0f ? Facing::SOUTH : Facing::NORTH;
+		mchr.m_hitSide = view.z >= 0.0f ? Facing::SOUTH : Facing::NORTH;
 	}
 	else
 	{
-		m_pMinecraft->m_hitResult.m_hitSide = view.x >= 0.0f ? Facing::EAST : Facing::WEST;
+		mchr.m_hitSide = view.x >= 0.0f ? Facing::EAST : Facing::WEST;
 	}
 }
 

--- a/source/client/renderer/GameRenderer.hpp
+++ b/source/client/renderer/GameRenderer.hpp
@@ -54,7 +54,7 @@ public:
 
 	float field_8;
 	int field_C;
-	Entity* field_10;
+	Entity* m_pHovered;
 	float field_14;
 	float field_18;
 	float field_1C;

--- a/source/world/entity/Creeper.cpp
+++ b/source/world/entity/Creeper.cpp
@@ -46,7 +46,7 @@ void Creeper::die(Entity* pCulprit)
 {
 	Monster::die(pCulprit);
 
-	if (pCulprit->getDescriptor().isType(EntityType::SKELETON))
+	if (pCulprit && pCulprit->getDescriptor().isType(EntityType::SKELETON))
 	{
 		spawnAtLocation(Item::record_01->m_itemID + m_random.nextInt(2), 1);
 	}

--- a/source/world/gamemode/CreativeMode.hpp
+++ b/source/world/gamemode/CreativeMode.hpp
@@ -15,7 +15,7 @@ class CreativeMode : public GameMode
 public:
 	CreativeMode(Minecraft*, Level&);
 
-	float getPickRange() const override { return 5.0f; }
+	//float getBlockReachDistance() const override { return 5.0f; } // 5.0f on Java
 	bool isCreativeType() const override { return true; }
 
 	void initPlayer(Player*) override;

--- a/source/world/gamemode/GameMode.cpp
+++ b/source/world/gamemode/GameMode.cpp
@@ -77,18 +77,24 @@ void GameMode::render(float f)
 {
 }
 
-float GameMode::getPickRange() const
+float GameMode::getBlockReachDistance() const
 {
-/*
-  if ( *inputMode == 1 )
-	return 5.7;
-  if ( *inputMode == 3 )
-	return 5.6;
-  if ( !player || player->isCreative() )
-	return 12.0;
-  return 5.0;
-*/
-	return 7.5f;
+	/* Logic from Pocket Edition 0.12.1
+	if ( *inputMode == 1 )
+		return 5.7f;
+	if ( *inputMode == 3 )
+		return 5.6f;
+	if ( !player || player->isCreative() )
+		return 12.0f;
+	*/
+
+	// Fallback on Java and Pocket. All GameModes on PE are 5.0f until 0.10.0-0.12.1
+	return 5.0f;
+}
+
+float GameMode::getEntityReachDistance() const
+{
+	return 5.0f;
 }
 
 LocalPlayer* GameMode::createPlayer(Level* pLevel)

--- a/source/world/gamemode/GameMode.hpp
+++ b/source/world/gamemode/GameMode.hpp
@@ -30,7 +30,9 @@ public:
 	virtual void stopDestroyBlock();
 	virtual void tick();
 	virtual void render(float f);
-	virtual float getPickRange() const;
+	// Used to be called getPickRange
+	virtual float getBlockReachDistance() const;
+	virtual float getEntityReachDistance() const;
 	virtual bool useItem(Player*, Level*, ItemInstance*);
 	virtual bool useItemOn(Player*, Level*, ItemInstance*, const TilePos& pos, Facing::Name face);
 	virtual LocalPlayer* createPlayer(Level*);

--- a/source/world/gamemode/SurvivalMode.hpp
+++ b/source/world/gamemode/SurvivalMode.hpp
@@ -21,7 +21,8 @@ public:
 	void stopDestroyBlock() override;
 	void tick() override;
 	void render(float f) override;
-	float getPickRange() const override { return 5.0f; }
+	float getBlockReachDistance() const override { return 4.0f; } // 4.0f on Java, 5.0f until 0.10.0-0.12.1
+	float getEntityReachDistance() const override { return 3.0f; }
 	bool isCreativeType() const override { return false; }
 	bool isSurvivalType() const override { return true; }
 	void initPlayer(Player*) override;


### PR DESCRIPTION
 * Fixed a bug causing players in Creative mode to be able to punch entities through blocks
 * Cleaned up block and entity reach for GameModes
 * Fixed null pointer dereference in Creeper::die()