### PR TITLE
Change TilePos::y from uint8_t to int

### DIFF
--- a/source/world/level/TilePos.cpp
+++ b/source/world/level/TilePos.cpp
@@ -21,7 +21,7 @@ TilePos::TilePos(int _x, int _y, int _z)
 
 TilePos::TilePos(float _x, float _y, float _z)
 {
-    _init((int)floorf(_x), (uint8_t)floorf(_y), (int)floorf(_z));
+    _init((int)floorf(_x), (int)floorf(_y), (int)floorf(_z));
 }
 
 TilePos::TilePos(const Vec3& pos)

--- a/source/world/level/TilePos.hpp
+++ b/source/world/level/TilePos.hpp
@@ -15,7 +15,7 @@ struct ChunkPos;
 struct TilePos
 {
 	int x;
-	uint8_t y; // 255 height limit
+	int y; // We had this on uint8_t due to the 255 height limit, but this can overflow too easily
 	int z;
     
 private:


### PR DESCRIPTION
 * Fixes integer overflow issues