### PR TITLE
fix build ipa script

### DIFF
--- a/platforms/ios/build-ipa.sh
+++ b/platforms/ios/build-ipa.sh
@@ -33,27 +33,16 @@ mkdir -p "$apppath"
 cp "build/$bin" "$apppath/$execname"
 sed -E -e "s|\\\$\{EXECUTABLE_NAME\}|$execname|" -e "s|\\\$\{PRODUCT_NAME(:rfc1034identifier)?\}|$execname|g" "$platformdir/minecraftpe-Info.plist" |
     plistutil -o "$apppath/Info.plist" -f bin
-cd "$assetdir"
-apppath="../../$apppath"
-if [ -f font/default.png ]; then
-    cp font/default.png "$apppath/default8.png"
-elif [ -f font/default8.png ]; then
-    cp font/default8.png "$apppath/default8.png"
-fi
-cp icon.png "$apppath/Icon.png" || true
+cp "$assetdir/icon.png" "$apppath/Icon.png" || true
 cp -a \
-    "../../$platformdir/precompiled"/* \
-    gui/*.png \
-    mob/* \
-    item/* \
-    sound/* \
-    sounds/random/* \
-    app/launch/* \
-    patches/* \
-    terrain.png \
-    particles.png \
+    "$platformdir/precompiled"/* \
+    "$assetdir" \
     "$apppath" || true
-cd "../../$ipadir"
+[ -f "$apppath/assets/font/default.png" ] && mv "$apppath/assets/font/default.png" "$apppath/assets/font/default8.png"
+mv "$apppath/assets/app/launch"/* "$apppath"
+rm -rf "$apppath/assets/app"
+find "$apppath" -name .gitignore -delete
+cd "$ipadir"
 rm -f "../$ipaname"
 zip -r "../$ipaname" Payload
 


### PR DESCRIPTION
The HAL PR changed the correct asset layout in the .app, this updates the build-ipa.sh script to correctly place assets again.