### PR TITLE
Fix issues with TARGET_OS_* macros

### DIFF
--- a/compat/PlatformDefinitions.h
+++ b/compat/PlatformDefinitions.h
@@ -25,7 +25,7 @@
 #endif
 
 /* Apple - Device Simulator */
-#define MC_PLATFORM_SIMULATOR (TARGET_OS_SIMULATOR || TARGET_IPHONE_SIMULATOR || __APPLE_EMBEDDED_SIMULATOR__)
+#define MC_PLATFORM_SIMULATOR __APPLE_EMBEDDED_SIMULATOR__
 
 /* Google - Android */
 #if (defined(ANDROID))


### PR DESCRIPTION
Apple clang doesn't define the TARGET_OS_* macros, I was getting warns when using the cmake build script on a mac, these macros should work for any compiler targetting Darwin, including GCC 4.