### PR TITLE
super ultra reliable macros

### DIFF
--- a/compat/PlatformDefinitions.h
+++ b/compat/PlatformDefinitions.h
@@ -8,24 +8,34 @@
 
 #pragma once
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #include "EndianDefinitions.h"
 
 /* Apple - Mac OS X / macOS */
-#ifdef __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
+#if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) || \
+    (defined(TARGET_OS_MAC) && TARGET_OS_MAC)
 #define MC_PLATFORM_MAC 1
 #else
 #define MC_PLATFORM_MAC 0
 #endif
 
 /* Apple - iPhoneOS / iOS */
-#ifdef __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__
+#if defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) || \
+    (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
 #define MC_PLATFORM_IOS 1
 #else
 #define MC_PLATFORM_IOS 0
 #endif
 
 /* Apple - Device Simulator */
-#define MC_PLATFORM_SIMULATOR __APPLE_EMBEDDED_SIMULATOR__
+#if defined(__APPLE_EMBEDDED_SIMULATOR__) || \
+    (defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR) || \
+    (defined(TARGET_IPHONE_SIMULATOR) || TARGET_IPHONE_SIMULATOR)
+#define MC_PLATFORM_SIMULATOR 1
+#endif
 
 /* Google - Android */
 #if (defined(ANDROID))


### PR DESCRIPTION
gcc 4.0 doesn't define `__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__`