### PR TITLE
Basic iOS build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,16 @@ To build, perform the same steps as on Linux.
 
 #### Dependencies (Ubuntu/Debian cross build)
 
-- `build-essential` (C/C++ Toolchain)
 - `clang` (Clang)
 - `llvm` (LLVM)
 - `cmake` (CMake)
 - `make` (GNU Make)
+- `pkg-config` (pkg-config)
 - `wget` (Wget)
+- `zip` (zip)
+- `libplist-utils` (plistutil)
 - `libplist-dev` (libplist development headers)
+- `libssl-dev` (OpenSSL development headers)
 
 #### How To Build
 


### PR DESCRIPTION
Only documents the CMake build from Ubuntu/Debian Linux, someone else can document the Xcode build.

When build documentation gets split up into different files for every platform, I'll add other distros' dependency names and stuff, but until then I wanna keep it brief to keep the main readme from getting too long.