### PR TITLE
Fix: Unstackable item duplication bug

### DIFF
--- a/source/world/item/Inventory.cpp
+++ b/source/world/item/Inventory.cpp
@@ -281,7 +281,7 @@ bool Inventory::addItem(ItemInstance& instance)
 		if (leftover < 0)
 			leftover = 0;
 		else
-			combinedItemAmount = C_MAX_INVENTORY_STACK_SIZE;
+			combinedItemAmount = maxStackSize;
 
 		item->m_count = combinedItemAmount;
 		item->m_popTime = C_POP_TIME_DURATION;


### PR DESCRIPTION
### Context
Fixed a bug where unstackable items like doors would duplicate when picked up if the player already had one of the same type in their inventory.

### Changes
When combining items into an existing slot in `Inventory::addItem()`, the code was incorrectly setting `combinedItemAmount = C_MAX_INVENTORY_STACK_SIZE` (64) instead of `maxStackSize` for items with leftover count. This caused unstackable items (maxStackSize=1) to be improperly stacked to 64, with the overflow creating duplicate items.

### Demo (after fix)

![mcpe](https://github.com/user-attachments/assets/660fecef-7c8a-4f10-8ab3-1baa14adbe53)

Closes #168 