### PR TITLE
Use constant CI versions instead of -lastest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
                     flags: '-DREMCPE_PLATFORM=sdl1 -DREMCPE_GFX_API=OGL'
                     packages: 'libsdl1.2-dev'
         name: Linux (${{ matrix.name }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
                 cmake --build .
     wasm:
         name: WASM
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
                   #  backend_name: 'SDL1'
                   #  packages: 'libsdl'
         name: macOS (${{ matrix.name }})
-        runs-on: macos-latest
+        runs-on: macos-15
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
                 clean archive 
     ios:
         name: iOS
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v3
@@ -123,7 +123,7 @@ jobs:
                   - name: Native
                     directory: platforms/android/project
         name: Android (${{ matrix.name }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
                   #- name: SDL 1.2
                   #  flags: '-DREMCPE_PLATFORM=sdl1 -DREMCPE_GFX_API=OGL'
         name: MinGW-w64 (${{ matrix.name }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v4


### PR DESCRIPTION
As pointed out by @iProgramMC on Discord, since CI builds with -Werror enabled, it's possible for it to break at random when github updates the 'latest' version, causing the compiler versions to change and new warnings to be added.  By manually specifying the version CI uses, we can easily fix any new warnings at the same time we update the CI versions, instead of having CI just be totally broken for a bit, or having to temporarily disable -Werror.