### PR TITLE
Fix inconsistent missing override warnings

### DIFF
--- a/platforms/audio/openal/SoundStreamOAL.hpp
+++ b/platforms/audio/openal/SoundStreamOAL.hpp
@@ -37,7 +37,7 @@ protected:
     bool _open(const std::string& fileName) override;
     void _close() override;
     void _update() override;
-    void _publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer);
+    void _publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer) override;
 
 private:
     std::vector<ALuint> m_buffers;

--- a/source/nbt/ListTag.hpp
+++ b/source/nbt/ListTag.hpp
@@ -61,7 +61,7 @@ public:
 	const CompoundTag* getCompound(unsigned int index) const;
 	Tag* copy() const override;
 	ListTag* copyList() const;
-	void deleteChildren();
+	void deleteChildren() override;
 
 	const std::vector<Tag*>& rawView() const { return m_list; }
 

--- a/source/world/entity/Arrow.hpp
+++ b/source/world/entity/Arrow.hpp
@@ -24,7 +24,7 @@ public:
 	void shoot(Vec3 pos, float speed, float r);
 	
 	void lerpMotion(float x, float y, float z) { lerpMotion(Vec3(x, y, z)); };
-	void lerpMotion(const Vec3& vel);
+	void lerpMotion(const Vec3& vel) override;
 
 	void tick() override;
 	void playerTouch(Player* pPlayer) override;

--- a/source/world/tile/DeadBush.hpp
+++ b/source/world/tile/DeadBush.hpp
@@ -7,5 +7,5 @@ class DeadBush : public Bush
 public:
 	DeadBush(int id, int texture);
 	int getResource(TileData, Random*) const override;
-	bool mayPlace(const Level*, const TilePos& pos) const;
+	bool mayPlace(const Level*, const TilePos& pos) const override;
 };


### PR DESCRIPTION
When building with Clang for C++11, I get a lot of `warning: 'foo' overrides a member function but is not marked 'override'`, this doesn't show up when building for C++98, but since we want to support building for C++11 for platforms that don't support C++98 like MinGW, we should fix these.