### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
                 cd build
                 cmake -GNinja -DWERROR=ON ${{ matrix.flags }} ..
                 cmake --build .
+
     wasm:
         name: WASM
         runs-on: ubuntu-24.04
@@ -52,6 +53,7 @@ jobs:
                 sudo apt-get install --no-install-recommends -y cmake ninja-build
           - name: Build
             run: ./build-wasm.sh -DWERROR=ON
+
     macos:
         strategy:
             fail-fast: false
@@ -88,13 +90,14 @@ jobs:
                 -destination generic/platform=macOS \
                 GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_DEFINITIONS)' \
                 -quiet \
-                clean archive 
+                clean archive
+
     ios:
         name: iOS
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout Repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
                 submodules: true
           - name: Install Dependencies
@@ -102,7 +105,12 @@ jobs:
                 wget https://apt.llvm.org/llvm.sh
                 sudo bash llvm.sh 21
                 sudo apt-get update
-                sudo apt-get install --no-install-recommends -y clang-21 libplist-dev libplist-utils libssl-dev
+                sudo apt-get install --no-install-recommends -y \
+                    cmake \
+                    clang-21 \
+                    libplist-utils \
+                    libplist-dev \
+                    libssl-dev
 
           - name: Build iOS binary
             run: ./platforms/ios/build.sh
@@ -113,6 +121,7 @@ jobs:
               LLVM_CONFIG: llvm-config-21
               REMCPE_NO_IPA: 1
               WERROR: ON
+
     android:
         strategy:
             fail-fast: false
@@ -138,7 +147,8 @@ jobs:
           - name: Build
             run: |
                 cd ${{ matrix.directory }}
-                ./gradlew build
+                ./gradlew assembleDebug
+
     mingw:
         strategy:
             fail-fast: false
@@ -175,6 +185,7 @@ jobs:
                 cd build
                 cmake -GNinja -DWERROR=ON -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-w64-toolchain.cmake ${{ matrix.flags }} ..
                 cmake --build .
+
     switch:
         name: Nintendo Switch
         runs-on: ubuntu-24.04
@@ -182,7 +193,7 @@ jobs:
             image: devkitpro/devkita64@sha256:7ca6fb93e8f576a65bbfe07b537b67664a974e06eabe4e94359e3e026a0f0b0c
         steps:
           - name: Checkout Repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
                 submodules: true
 


### PR DESCRIPTION
Most important change is making Android builds twice as fast by only building debug, not release.  Also does some basic formatting and updates actions/checkout.