### PR TITLE
Remove ELF file from NX artifacts

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -253,5 +253,4 @@ jobs:
               name: Nintendo Switch
               path: |
                 build/platforms/sdl/sdl2/reminecraftpe.nro
-                build/reminecraftpe.elf
                 build/assets


### PR DESCRIPTION
.elf is inflating the Nintendo Switch artifact by 60mbs (actual size around 25mbs as compressed to zip), apparently reason was _Debug Symbols_ but who's gonna use pre-built binary for debugging?