### PR TITLE
Hit select render fix

### DIFF
--- a/source/client/renderer/LevelRenderer.cpp
+++ b/source/client/renderer/LevelRenderer.cpp
@@ -1304,6 +1304,7 @@ void LevelRenderer::renderHitSelect(const Entity& camera, const HitResult& hr, i
 		pTile = Tile::tiles[tileID];
 
 	currentShaderColor = Color(0.65f, 0.65f, 0.65f, 0.65f);
+	currentShaderDarkColor = Color::WHITE;
 
 	MatrixStack::Ref matrix = MatrixStack::World.push();
 
@@ -1333,6 +1334,7 @@ void LevelRenderer::renderHitOutline(const Entity& camera, const HitResult& hr, 
 		return;
 
 	currentShaderColor = Color(0.0f, 0.0f, 0.0f, 0.4f);
+	currentShaderDarkColor = Color::WHITE;
 
 	constexpr float distance = 0.002f;
 	float lineWidth = 2.0f * Minecraft::getRenderScaleMultiplier();


### PR DESCRIPTION
The before is pretty self explanatory, see photo below of bug. Entities change the darker color at night, it wasn't getting reset, so everything was dark. Now it's not. Riveting stuff

![](https://cdn.discordapp.com/attachments/963844139689050173/1467676436063059988/image.png?ex=69813fb2&is=697fee32&hm=50f657753a1177ff3dba66a554bab3c78f513aaf3c33f2e31534a820b44f8777&)