### PR TITLE
Fix switch artifact folder structure

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -249,10 +249,11 @@ jobs:
                 cd build
                 /opt/devkitpro/portlibs/switch/bin/aarch64-none-elf-cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
                 /opt/devkitpro/portlibs/switch/bin/aarch64-none-elf-cmake --build .
+                mv platforms/sdl/sdl2/reminecraftpe.nro .
           - uses: actions/upload-artifact@v6
             with:
               name: Nintendo Switch
               path: |
-                build/platforms/sdl/sdl2/reminecraftpe.nro
+                build/reminecraftpe.nro
                 build/reminecraftpe.elf
                 build/assets


### PR DESCRIPTION
The zip would have the nro file behind a few nested folders instead of at the root of the zip before.