### PR TITLE
Close inventory by pressing E

### DIFF
--- a/source/client/gui/Gui.cpp
+++ b/source/client/gui/Gui.cpp
@@ -43,7 +43,7 @@ Gui::Gui(Minecraft* pMinecraft)
 	field_24 = 0;
 	field_28 = 0;
 	field_2C = 0;
-	m_ticks = 0;
+	field_9FC = 0;
 	field_A00 = "";
 	field_A18 = 0;
 	field_A1C = false;
@@ -221,7 +221,7 @@ void Gui::tick()
 	if (field_A18 > 0)
 		field_A18--;
 
-	m_ticks++;
+	field_9FC++;
 
 	for (size_t i = 0; i < m_guiMessages.size(); i++)
 	{
@@ -455,7 +455,6 @@ void Gui::renderHearts(bool topLeft)
 
 	int playerHealth = player->m_health;
 
-	m_random.setSeed(static_cast<int32_t>(field_9FC * 312871));
 	for (int healthNo = 1; healthNo <= C_MAX_MOB_HEALTH; healthNo += 2)
 	{
 		int heartY = heartYStart;

--- a/source/client/gui/Gui.hpp
+++ b/source/client/gui/Gui.hpp
@@ -95,7 +95,7 @@ public:
 	int field_2C;
 	Random m_random;
 	Minecraft* m_pMinecraft;
-	int m_ticks;
+	int field_9FC;
 	std::string field_A00;
 	int field_A18;
 	bool field_A1C;


### PR DESCRIPTION
On the tin. Yes, it should work in all container types, including chests and crafting tables. It's an alternate escape that matches the Java behavior