### PR TITLE
Use logf instead of log in Random::nextGaussian

### DIFF
--- a/source/common/Random.cpp
+++ b/source/common/Random.cpp
@@ -128,7 +128,7 @@ float Random::nextGaussian()
 		s = v1 * v1 + v2 * v2;
 	}
 	while (s >= 1 || s == 0);
-	float mult = sqrtf(-2 * log(s) / s);
+	float mult = sqrtf(-2 * logf(s) / s);
 	nextNextGaussian = v2 * mult;
 	return v1 * mult;
 }


### PR DESCRIPTION
log is the double version of the function, and using it means casting our float to double and back, plus the function itself is prolly slower.