### PR TITLE
Build artifacts with LTO when possible

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -196,6 +196,7 @@ jobs:
               AR: llvm-ar-21
               RANLIB: llvm-ranlib-21
               LLVM_CONFIG: llvm-config-21
+              NOSTRIP: 1
           - uses: actions/upload-artifact@v6
             with:
               name: iOS

--- a/platforms/ios/build.sh
+++ b/platforms/ios/build.sh
@@ -165,7 +165,7 @@ for target in $targets; do
 done
 
 lipo -create "$workdir/$bin"-* -output "build/$bin"
-[ -z "$DEBUG" ] && "$strip" -no_code_signature_warning "build/$bin"
+[ -z "$DEBUG" ] && [ -z "$NOSTRIP" ] && "$strip" -no_code_signature_warning "build/$bin"
 if command -v ldid >/dev/null; then
     ldid -S"$entitlements" "build/$bin"
 else


### PR DESCRIPTION
Enables LTO on Linux, Windows, and Switch.  Reduces binary size a pretty good amount on all mentioned platforms, probably improves performance too.
Also adds logic to stop iOS artifacts from being stripped.