### PR TITLE
Fix msvc build after #368

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -2,7 +2,7 @@ name: 'Build Artifacts'
 
 on:
   push:
-    branches: [ 'msvc-fix' ]
+    branches: [ 'master' ]
 
 jobs:
     linux:


### PR DESCRIPTION
MSVC rc.exe doesn't define `_MSC_VER`, so we gotta use `__GNUC__` instead.