### PR TITLE
static constexpr macro

### DIFF
--- a/compat/LegacyCPP_Compat.hpp
+++ b/compat/LegacyCPP_Compat.hpp
@@ -4,7 +4,7 @@
 
 #ifdef USE_OLD_CPP
 
-#define CONSTEXPR
+#define CONSTEXPR_FUNC static
 #ifndef constexpr
 #define constexpr const
 #endif
@@ -39,7 +39,7 @@ namespace std
 #endif // !defined(_WIN32)*/
 
 #else
-#define CONSTEXPR constexpr
+#define CONSTEXPR_FUNC constexpr
 #endif // USE_OLD_CPP
 
 // https://gcc.gnu.org/legacy-ml/gcc-help/2006-04/msg00062.html

--- a/source/common/Mth.hpp
+++ b/source/common/Mth.hpp
@@ -53,7 +53,7 @@ public:
 		return (T(0) < val) - (val < T(0));
 	}
     
-	static inline CONSTEXPR float Lerp(float a, float b, float progress)
+	static inline CONSTEXPR_FUNC float Lerp(float a, float b, float progress)
 	{
 		return a + progress * (b - a);
 	}

--- a/source/world/level/levelgen/chunk/LevelChunk.cpp
+++ b/source/world/level/levelgen/chunk/LevelChunk.cpp
@@ -19,12 +19,12 @@ LevelChunk::~LevelChunk()
 	SAFE_DELETE_ARRAY(m_tileData.m_data);
 }
 
-CONSTEXPR int MakeBlockDataIndex(const ChunkTilePos& pos)
+CONSTEXPR_FUNC int MakeBlockDataIndex(const ChunkTilePos& pos)
 {
 	return (pos.x << 11) | (pos.z << 7) | pos.y;
 }
 
-CONSTEXPR int MakeHeightMapIndex(const ChunkTilePos& pos)
+CONSTEXPR_FUNC int MakeHeightMapIndex(const ChunkTilePos& pos)
 {
 	return pos.x | (pos.z * 16);
 }

--- a/source/world/level/path/PathFinder.cpp
+++ b/source/world/level/path/PathFinder.cpp
@@ -13,7 +13,7 @@
 static int dword_1CD868;
 static int dword_1CD870;
 
-CONSTEXPR int MakeNodeHash(const TilePos& pos)
+CONSTEXPR_FUNC int MakeNodeHash(const TilePos& pos)
 {
 	// NOTE: Same as in Java Edition Beta 1.3_01
 	return (pos.y & 0xFF) | 


### PR DESCRIPTION
~~Renames the CONSTEXPR macro to CONSTEXPR_FUNC and defines it to static on C++98.
This should very slightly improve code size and speed.~~
constexpr doesn't work like that apperently