### PR TITLE
Fixes in macOS artifact build

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -2,7 +2,7 @@ name: 'Build Artifacts'
 
 on:
   push:
-    branches: [ 'mac-artifact-pentium-m' ]
+    branches: [ 'master' ]
 
 jobs:
     linux:


### PR DESCRIPTION
SDL1 was previously being build without optimizations on release builds, and with optimizations on debug builds because of a flipped check.
We now build i386 for pentium-m instead of the default of yonah, this allows a hacked Apple TV 1st generation to run the game at a somewhat respectable framerate, at the cost of not using SSE3 instructions, performance impact probably isn't very noticeable.