### PR TITLE
Xbox 360 / Console Bug Fixes

### DIFF
--- a/game/assets/lang/en_us.json
+++ b/game/assets/lang/en_us.json
@@ -28,7 +28,7 @@
     "loadingTip.junkboysFace": "No-one at Mojang has ever seen junkboy's face.",
     "loadingTip.largeChest": "Placing two chests side by side will make one large chest.",
     "loadingTip.lavaSmelt": "A single bucket of lava can be used in a furnace to smelt 100 blocks.",
-    "loadingTip.legacyInfo": "You'll get the latest info on this game from minecraft.net!",
+    "loadingTip.legacyInfo": "You'll get the latest info on this game from our Discord!",
     "loadingTip.lightMelt": "Blocks that can be used as a light source will melt snow and ice. This includes torches, glowstone, and Jack O'Lanterns.",
     "loadingTip.minecart": "Get to destinations faster with a minecart and rail!",
     "loadingTip.mineconCalifornia": "Minecon 2016 was in Anaheim, California, USA!",

--- a/game/assets/texts/tips.json
+++ b/game/assets/texts/tips.json
@@ -192,9 +192,6 @@
         "translate": "loadingTip.updateInfo"
     },
     {
-        "translate": "loadingTip.animalFollow"
-    },
-    {
         "translate": "loadingTip.mineconLondon"
     },
     {

--- a/platforms/xdk360/main.cpp
+++ b/platforms/xdk360/main.cpp
@@ -12,8 +12,16 @@ void _setSize()
 {
     XVIDEO_MODE VideoMode;
     XGetVideoMode(&VideoMode);
-    Minecraft::width  = Mth::Max(VideoMode.dwDisplayWidth, 1280);
-    Minecraft::height = Mth::Max(VideoMode.dwDisplayHeight, 720);
+    Minecraft::width  = Mth::Max(VideoMode.dwDisplayWidth, 640);
+    Minecraft::height = Mth::Max(VideoMode.dwDisplayHeight, 480);
+
+	// Hardcoded 1080p check to avoid failed D3D device creation attempt
+	if (Minecraft::width == 1920 && Minecraft::height == 1080)
+	{
+		// too big, D3D9 Device creation will fail
+		Minecraft::width = 1280;
+		Minecraft::height = 720;
+	}
 }
 
 void _onKeyboardClosed()

--- a/source/client/app/Minecraft.cpp
+++ b/source/client/app/Minecraft.cpp
@@ -1059,11 +1059,15 @@ float Minecraft::getBestScaleForThisScreenSize(int width, int height)
 #define USE_JAVA_SCREEN_SCALING
 #endif
 #ifdef USE_JAVA_SCREEN_SCALING
-	int scale;
-	for (scale = 1; width / (scale + 1) >= 320 && height / (scale + 1) >= 240; ++scale)
+	// @HACK: the scaling code for Java/Pocket Screens when using the Console theme is pretty broken
+	if (m_pOptions->getUiTheme() != UI_CONSOLE)
 	{
+		int scale;
+		for (scale = 1; width / (scale + 1) >= 320 && height / (scale + 1) >= 240; ++scale)
+		{
+		}
+		return scale;
 	}
-	return scale;
 #endif
 
 	if (height > 1800)

--- a/source/renderer/hal/d3d9/RenderContextD3D9.cpp
+++ b/source/renderer/hal/d3d9/RenderContextD3D9.cpp
@@ -167,12 +167,12 @@ void RenderContextD3D9::createWindowSizeDependentResources(HWND hWnd, unsigned i
         {
             d3dpp.BackBufferWidth = width;
             d3dpp.BackBufferHeight = height;
-            d3dpp.BackBufferFormat = D3DFMT_X8R8G8B8;
+            d3dpp.BackBufferFormat = D3DFMT_A8R8G8B8;
             d3dpp.BackBufferCount = 1;
             d3dpp.EnableAutoDepthStencil = TRUE;
             d3dpp.AutoDepthStencilFormat = D3DFMT_D24S8;
             d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;
-            d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
+            d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_ONE; // basically V-Sync
             if (hWnd)
             {
                 d3dpp.hDeviceWindow = hWnd;
@@ -181,8 +181,23 @@ void RenderContextD3D9::createWindowSizeDependentResources(HWND hWnd, unsigned i
         }
 
         DWORD flags = D3DCREATE_HARDWARE_VERTEXPROCESSING;
+		LOG_I("Creating IDirect3DDevice9 with %dx%d size...", width, height);
         HRESULT hResult = m_pD3D->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, NULL, flags, &d3dpp, *m_d3dDevice);
-        ErrorHandlerD3D9::checkForErrors(hResult);
+
+		if (hResult == E_OUTOFMEMORY)
+		{
+			width = 1280;
+			height = 720;
+            d3dpp.BackBufferWidth = width;
+            d3dpp.BackBufferHeight = height;
+			LOG_I("Failed to create IDirect3DDevice9! Falling back to (%dx%d)...", width, height);
+			HRESULT hResult = m_pD3D->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, NULL, flags, &d3dpp, *m_d3dDevice);
+			ErrorHandlerD3D9::checkForErrors(hResult);
+		}
+		else
+		{
+			ErrorHandlerD3D9::checkForErrors(hResult);
+		}
 
         m_d3dDevice->SetRenderState(D3DRS_SEPARATEALPHABLENDENABLE, TRUE);
         m_d3dDevice->SetRenderState(D3DRS_TWOSIDEDSTENCILMODE, TRUE);


### PR DESCRIPTION
* Added 720p fallback resolution for Direct3D 9 device initialization. This fixes crashes that would occur when launching the game in 1080p on the Xbox 360.
* Added a hack to fix screens being shrunk infinitely when using Java screen scaling with the Cconsole UI theme.
* Removed gameTips.animalFollow from tips, since the localization string was missing