### PR TITLE
Restored unsued camera flash texture

### DIFF
--- a/source/client/renderer/ItemInHandRenderer.cpp
+++ b/source/client/renderer/ItemInHandRenderer.cpp
@@ -234,7 +234,7 @@ void ItemInHandRenderer::renderItem(const Entity& entity, const ItemStack& item,
         t.vertexUV(1.0f, 0.0f, -C_ONE_PIXEL, texU_1, texV_2);
         t.vertexUV(0.0f, 0.0f, -C_ONE_PIXEL, texU_2, texV_2);
         
-        SHADE_IF_NEEDED(0.8f);
+        SHADE_IF_NEEDED(1.0f);
         t.normal(Vec3::NEG_UNIT_X);
         for (int i = 0; i < 16; i++)
         {
@@ -251,7 +251,7 @@ void ItemInHandRenderer::renderItem(const Entity& entity, const ItemStack& item,
             t.vertexUV((i + 1) * C_ONE_PIXEL, 0.0f, -C_ONE_PIXEL, Mth::Lerp(texU_2, texU_1, i * C_ONE_PIXEL) - C_RATIO_2, texV_2);
         }
         
-        SHADE_IF_NEEDED(0.6f);
+        SHADE_IF_NEEDED(1.0f);
         for (int i = 0; i < 16; i++)
         {
             t.vertexUV(0.0f, (i + 1) * C_ONE_PIXEL, 0.0f,         texU_2, Mth::Lerp(texV_2, texV_1, i * C_ONE_PIXEL));

--- a/source/world/entity/Animal.cpp
+++ b/source/world/entity/Animal.cpp
@@ -76,7 +76,7 @@ float Animal::getWalkTargetValue(const TilePos& pos) const
 	return m_pLevel->getBrightness(pos) - 0.5f;
 }
 
-bool Animal::hurt(Entity* pCulprit, int damage)
+/*bool Animal::hurt(Entity* pCulprit, int damage)
 {
 	// Run around erratically for three seconds.
 	field_BA4 = 60;
@@ -85,7 +85,7 @@ bool Animal::hurt(Entity* pCulprit, int damage)
 	field_BB4 = 0;
 
 	return Mob::hurt(pCulprit, damage);
-}
+}*/
 
 bool Animal::removeWhenFarAway() const
 {

--- a/source/world/entity/Animal.hpp
+++ b/source/world/entity/Animal.hpp
@@ -21,7 +21,7 @@ public:
 	Entity* findAttackTarget() override;
 	int getAmbientSoundInterval() const override;
 	float getWalkTargetValue(const TilePos& pos) const override;
-	bool hurt(Entity* pCulprit, int damage) override;
+	//bool hurt(Entity* pCulprit, int damage) override;
 	bool removeWhenFarAway() const override;
 
 	int getAge() const;


### PR DESCRIPTION

https://github.com/user-attachments/assets/6765e1bb-6f08-4390-9013-75c38df9af5c

- Restores the unused flash texture found in camera.png.
- Commented out erratic animal behavior, which is a b1.8 feature, and is currently broken.
- Made the shade if needed 1.0f for held items for Java accuracy, because the sides of items were too dark.