### PR TITLE
fix use-after-free

### DIFF
--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -86,36 +86,26 @@ static void initGraphics()
 
 static std::string getStoragePath()
 {
-    // Doing this as a c-string because worst-case, an SDK
-    // will return a nullptr instead of an empty string
-    const char* pathBase;
+    std::string path;
+    const char *tmp;
 #ifdef _WIN32
-    pathBase = getenv("APPDATA");
+    tmp = getenv("APPDATA");
+    if (tmp)
+        path = tmp;
 #else
-    std::string tmp;
-    const char *xdg_data = getenv("XDG_DATA_HOME");
-    if (xdg_data)
-        pathBase = xdg_data;
+    tmp = getenv("XDG_DATA_HOME");
+    if (tmp)
+        path = tmp;
     else
     {
-        xdg_data = getenv("HOME");
-        if (!xdg_data)
-        {
-            LOG_E("HOME not set");
-            pathBase = ""; // current working directory
-        }
+        tmp = getenv("HOME");
+        if (tmp)
+            path = std::string(tmp) + "/.local/share";
         else
-        {
-            tmp = (std::string)xdg_data + "/.local/share";
-            pathBase = tmp.c_str();
-        }
+            LOG_E("HOME not set");
     }
 #endif
 
-    if (!pathBase)
-        pathBase = ""; // just use the current working directory
-
-    std::string path(pathBase);
     if (!path.empty())
         path += "/";
     path += ".reminecraftpe";


### PR DESCRIPTION
According to clang this causes a UAF because the std::string is destroyed, fixed by declaring the temporary std::string in a different scope.