### PR TITLE
PPC artifact script fixes

### DIFF
--- a/platforms/macos/build.sh
+++ b/platforms/macos/build.sh
@@ -198,7 +198,7 @@ fi
 
 # Increase this if we ever make a change to the toolchain, for example
 # using a newer GCC version, and we need to invalidate the cache.
-ppctoolchainver=1
+ppctoolchainver=2
 ppc_triple='powerpc-apple-darwin8'
 targets="$targets $ppc_triple"
 if [ "$(cat toolchain-ppc/toolchainver 2>/dev/null)" != "$ppctoolchainver" ]; then


### PR DESCRIPTION
Fixes x86_64 build failing on Linux.
Reduces the size of the ppc toolchain by like 90% on Linux, 50% on macOS, mostly from stripping GCC.
Disables LTO for PPC builds, it was accidentally not being used on the main executable before, testing shows it doesn't help performance much and bloats binary size a LOT (35 MB when used for the whole build)