### PR TITLE
Better createFolderIfNotExists

### DIFF
--- a/source/common/Utils.cpp
+++ b/source/common/Utils.cpp
@@ -147,6 +147,8 @@ void closedir(DIR* dir)
 
 bool createFolderIfNotExists(const char* pDir)
 {
+	if (XPL_ACCESS(pDir, 0) == 0)
+		return true;
 	size_t pathlen = strlen(pDir);
 	std::stack<std::string> st;
 
@@ -171,9 +173,8 @@ bool createFolderIfNotExists(const char* pDir)
 		st.pop();
 	}
 
-	if (XPL_ACCESS(pDir, 0))
-		if (XPL_MKDIR(pDir, 0755) != 0)
-			return false;
+	if (XPL_MKDIR(pDir, 0755) != 0)
+		return false;
 	return true;
 }
 


### PR DESCRIPTION
Uses a stack and iterates backwards to cut down on syscalls.  Also fixes a bug on iOS 3 where the games/org.nbcraft directory wouldn't be created due to `access("/var", 0)` returning `ENOENT`.