### PR TITLE
Fix encoding of Win32 RC file

### DIFF
--- a/platforms/windows/NBCraftClient.Win32.rc
+++ b/platforms/windows/NBCraftClient.Win32.rc
@@ -1,4 +1,4 @@
-﻿// Microsoft Visual C++ generated resource script.
+// Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
 


### PR DESCRIPTION
Strangely, just re-encoding the RC file to normal UTF-8, instead of UTF-8 with BOM, fixes the build issue on my end.