### PR TITLE
Remove buffer limits in Util::vformat

### DIFF
--- a/source/common/Util.cpp
+++ b/source/common/Util.cpp
@@ -53,7 +53,11 @@ std::string Util::vformat(const char *fmt, va_list argPtr)
 {
 	va_list argPtr2;
 	va_copy(argPtr2, argPtr);
+#ifdef _WIN32
+	int len = _vscprintf(fmt, argPtr2);
+#else
 	int len = vsnprintf(nullptr, 0, fmt, argPtr2);
+#endif
 	va_end(argPtr2);
 	if (len < 0)
 		return "";


### PR DESCRIPTION
closes #550

This is a lot less efficient since we run snprintf twice, there is no other way around this.
@bluepilledgreat Do we even want this?  If 1024 isn't enough we can just make it 2048 or 4096 instead, running printf twice is inefficient.