### PR TITLE
Fix debug builds crashing on ppc macOS emulated with qemu

### DIFF
--- a/platforms/audio/openal/SoundStreamOAL.cpp
+++ b/platforms/audio/openal/SoundStreamOAL.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdexcept>
 
 #include "SoundStreamOAL.hpp"
 #include "common/Logger.hpp"
@@ -6,6 +7,9 @@
 SoundStreamOAL::SoundStreamOAL()
 {
     _createSource();
+    ALCenum err = alGetError();
+    if (err != AL_NO_ERROR)
+        throw std::runtime_error("audio init failed");
     _createBuffers();
     m_alFormat = AL_NONE;
 

--- a/platforms/audio/openal/SoundSystemOAL.cpp
+++ b/platforms/audio/openal/SoundSystemOAL.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdexcept>
 
 #include "CustomSoundSystem.hpp"
 
@@ -405,7 +406,14 @@ void SoundSystemOAL::startEngine()
 	alListenerfv(AL_VELOCITY, velocity);
 	AL_ERROR_CHECK();*/
 
-	m_musicStream = new SoundStreamOAL();
+	try
+	{
+		m_musicStream = new SoundStreamOAL();
+	}
+	catch (const std::runtime_error& e)
+	{
+		return;
+	}
     
 	// Mark As loaded
 	m_bInitialized = true;


### PR DESCRIPTION
Audio failed to initialize and some asserts got hit causing a crash, use exceptions to gracefully disable audio instead.