### PR TITLE
Rendering Performance Improvements

### DIFF
--- a/projects/visual-studio/Common/Common.vcxproj
+++ b/projects/visual-studio/Common/Common.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="$(MC_ROOT)\source\common\utility\JsonParser.cpp" />
     <ClCompile Include="$(MC_ROOT)\source\common\utility\Singleton.cpp" />
     <ClCompile Include="$(MC_ROOT)\source\common\threading\AsyncTask.cpp" />
+    <ClCompile Include="$(MC_ROOT)\source\common\utility\ByteBuffer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MC_ROOT)\source\common\threading\CThread.hpp" />
@@ -115,6 +116,7 @@
     <ClInclude Include="$(MC_ROOT)\source\common\utility\JsonParser.hpp" />
     <ClInclude Include="$(MC_ROOT)\source\common\utility\Singleton.hpp" />
     <ClInclude Include="$(MC_ROOT)\source\common\threading\AsyncTask.hpp" />
+    <ClInclude Include="$(MC_ROOT)\source\common\utility\ByteBuffer.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/projects/visual-studio/Common/Common.vcxproj.filters
+++ b/projects/visual-studio/Common/Common.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClCompile Include="$(MC_ROOT)\source\common\threading\AsyncTask.cpp">
       <Filter>Source Files\Threading</Filter>
     </ClCompile>
+    <ClCompile Include="$(MC_ROOT)\source\common\utility\ByteBuffer.cpp">
+      <Filter>Source Files\Utility</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MC_ROOT)\source\common\Logger.hpp">
@@ -126,6 +129,9 @@
     </ClInclude>
     <ClInclude Include="$(MC_ROOT)\source\common\threading\AsyncTask.hpp">
       <Filter>Header Files\Threading</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MC_ROOT)\source\common\utility\ByteBuffer.hpp">
+      <Filter>Header Files\Utility</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/projects/xcode/NBCraft.xcodeproj/project.pbxproj
+++ b/projects/xcode/NBCraft.xcodeproj/project.pbxproj
@@ -836,6 +836,8 @@
 		84DAF5982F34650500D67310 /* SetEntityMotionPacket.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 84DAF5862F34650500D67310 /* SetEntityMotionPacket.hpp */; };
 		84DAF5992F34650500D67310 /* TileEventPacket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84DAF5872F34650500D67310 /* TileEventPacket.cpp */; };
 		84DAF59A2F34650500D67310 /* TileEventPacket.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 84DAF5882F34650500D67310 /* TileEventPacket.hpp */; };
+		84DEAB542F8CBB0D00BD9701 /* ByteBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84DEAB522F8CBB0D00BD9701 /* ByteBuffer.cpp */; };
+		84DEAB552F8CBB0D00BD9701 /* ByteBuffer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 84DEAB532F8CBB0D00BD9701 /* ByteBuffer.hpp */; };
 		84DED1982F3095B8004001C5 /* CraftingScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84DED1962F3095B8004001C5 /* CraftingScreen.cpp */; };
 		84DED1992F3095B8004001C5 /* CraftingScreen.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 84DED1972F3095B8004001C5 /* CraftingScreen.hpp */; };
 		84DED19C2F3095FD004001C5 /* CraftingMenu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84DED19A2F3095FD004001C5 /* CraftingMenu.cpp */; };
@@ -2604,6 +2606,8 @@
 		84DAF5862F34650500D67310 /* SetEntityMotionPacket.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SetEntityMotionPacket.hpp; sourceTree = "<group>"; };
 		84DAF5872F34650500D67310 /* TileEventPacket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TileEventPacket.cpp; sourceTree = "<group>"; };
 		84DAF5882F34650500D67310 /* TileEventPacket.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TileEventPacket.hpp; sourceTree = "<group>"; };
+		84DEAB522F8CBB0D00BD9701 /* ByteBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ByteBuffer.cpp; path = utility/ByteBuffer.cpp; sourceTree = "<group>"; };
+		84DEAB532F8CBB0D00BD9701 /* ByteBuffer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = ByteBuffer.hpp; path = utility/ByteBuffer.hpp; sourceTree = "<group>"; };
 		84DED1962F3095B8004001C5 /* CraftingScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CraftingScreen.cpp; sourceTree = "<group>"; };
 		84DED1972F3095B8004001C5 /* CraftingScreen.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CraftingScreen.hpp; sourceTree = "<group>"; };
 		84DED19A2F3095FD004001C5 /* CraftingMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CraftingMenu.cpp; sourceTree = "<group>"; };
@@ -3573,6 +3577,8 @@
 		840DD6252AC810620006A435 /* common */ = {
 			isa = PBXGroup;
 			children = (
+				84DEAB522F8CBB0D00BD9701 /* ByteBuffer.cpp */,
+				84DEAB532F8CBB0D00BD9701 /* ByteBuffer.hpp */,
 				84CCBC3D2E6183F300E251AF /* DataIO.cpp */,
 				84CCBC3E2E6183F300E251AF /* DataIO.hpp */,
 				840DD6282AC810620006A435 /* Logger.cpp */,
@@ -6110,6 +6116,7 @@
 				8406FD3B2AF1823700B09C1D /* Utils.hpp in Headers */,
 				84E001B92AF3A3CB009B9555 /* SmoothFloat.hpp in Headers */,
 				84C0D8032B15A1D0007E1E76 /* PlatformDefinitions.h in Headers */,
+				84DEAB552F8CBB0D00BD9701 /* ByteBuffer.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7239,6 +7246,7 @@
 				84EB0E102EE2D4D4008FB007 /* JsonParser.cpp in Sources */,
 				84E4BFB62AE9869A0023E16A /* Logger.cpp in Sources */,
 				84E4BFB82AE9869A0023E16A /* Mth.cpp in Sources */,
+				84DEAB542F8CBB0D00BD9701 /* ByteBuffer.cpp in Sources */,
 				84E4BFB92AE9869A0023E16A /* Random.cpp in Sources */,
 				84E4BFBB2AE9869A0023E16A /* Timer.cpp in Sources */,
 				84E058FC2F383E9200F1E829 /* AsyncTask.cpp in Sources */,

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(nbcraft-core STATIC
     common/utility/AlignmentHelper.cpp
     common/utility/JsonParser.cpp
     common/utility/Singleton.cpp
+	common/utility/ByteBuffer.cpp
     common/Utils.cpp
     client/app/App.cpp
     client/app/AppPlatform.cpp

--- a/source/client/gui/Gui.cpp
+++ b/source/client/gui/Gui.cpp
@@ -195,7 +195,7 @@ void Gui::render(float f, bool bHaveScreen, int mouseX, int mouseY)
 		textures.loadAndBindTexture("gui/icons.png");
 
 		Tesselator& t = Tesselator::instance;
-		t.begin(0);
+		t.begin(160);
 		t.voidBeginAndEndCalls(true);
 
 		renderHearts(isPocket);

--- a/source/client/gui/screens/CreditsScreen.cpp
+++ b/source/client/gui/screens/CreditsScreen.cpp
@@ -73,7 +73,7 @@ void CreditsScreen::render(float f)
 	float widthf = float(m_width);
 	float heightf = float(m_height);
 	float heightsub32 = heightf - 32;
-	t.begin(4);
+	t.begin(8);
 	t.color(0x505050, 255);
 	t.vertexUV(0.0f, heightf, 0.0f, 0.0f, heightf / 32.0f);
 	t.vertexUV(widthf, heightf, 0.0f, widthf / 32.0f, heightf / 32.0f);

--- a/source/client/renderer/LevelRenderer.cpp
+++ b/source/client/renderer/LevelRenderer.cpp
@@ -302,7 +302,7 @@ void LevelRenderer::_renderSunrise(float alpha)
 
 		int steps = 16;
 
-		t.begin(mce::PRIMITIVE_MODE_TRIANGLE_STRIP, steps * 2);
+		t.begin(mce::PRIMITIVE_MODE_TRIANGLE_STRIP, (steps * 2) + 2);
 
 		for (int i = 0; i <= steps; i++)
 		{

--- a/source/client/renderer/LevelRenderer.cpp
+++ b/source/client/renderer/LevelRenderer.cpp
@@ -1865,11 +1865,11 @@ void LevelRenderer::renderAdvancedClouds(float alpha)
 #endif
 		}
 
+		t.begin(3216); // it doesn't get any bigger than this
 		for (int xPos = -radius + 1; xPos <= radius; xPos++)
 		{
 			for (int zPos = -radius + 1; zPos <= radius; zPos++)
 			{
-				t.begin(0);
 				float xx = xPos * D;
 				float zz = zPos * D;
 				float xp = xx - xoffs;
@@ -1948,10 +1948,10 @@ void LevelRenderer::renderAdvancedClouds(float alpha)
 						t.vertexUV((xp + 0.0f), (yy + 0.0f), (zp + i + 1.0f - e), ((xx + 0.0f) * scale + uo), ((zz + i + 0.5f) * scale + vo));
 					}
 				}
-
-				t.draw(m_materials.clouds);
 			}
 		}
+
+		t.draw(m_materials.clouds);
 	}
 
 	if (yy > 1.0f)

--- a/source/client/renderer/TileRenderer.cpp
+++ b/source/client/renderer/TileRenderer.cpp
@@ -2711,7 +2711,7 @@ void TileRenderer::renderTile(const FullTile& tile, const mce::MaterialPtr& mate
 #define IF_NEEDED(x) do { if (tile.data != 255) { (x); } } while (0)
 
 			t.addOffset(-0.5f, -0.5f, -0.5f);
-			t.begin(0);
+			t.begin(24); // 4 to 24
 			SHADE_DEFINE;
 			SHADE_PREPARE;
 			SHADE_IF_NEEDED(1.0f);

--- a/source/client/renderer/renderer/Tesselator.cpp
+++ b/source/client/renderer/renderer/Tesselator.cpp
@@ -119,7 +119,7 @@ Tesselator::~Tesselator()
 void* Tesselator::_allocateIndices(int count)
 {
 	m_indices.resize(m_indexSize * count);
-	return &m_indices.front();
+	return m_indices.data();
 }
 
 void Tesselator::_tex(const Vec2& uv, int count)
@@ -248,7 +248,7 @@ void Tesselator::beginIndices(int maxIndices)
 		maxIndices *= m_indexSize;
 	}
 
-	m_indices.resize(m_indices.size() + maxIndices);
+	m_indices.resize(m_indices.getSize() + maxIndices);
 }
 
 void Tesselator::draw(const mce::MaterialPtr& materialPtr)
@@ -280,10 +280,11 @@ mce::Mesh Tesselator::end(const char* debugName, bool temporary)
 			m_indexCount,
 			m_indexSize,
 			m_drawMode,
-			&m_indices[0],
+			m_indices,
 			temporary);
 
-		if (!temporary)
+		// check if the GFX Buffer took ownership of the data, this is only done by client-sided buffers (for now)
+		if (!temporary || !m_indices)
 			clear();
 
 		return mesh;
@@ -432,7 +433,7 @@ void Tesselator::vertex(float x, float y, float z)
 	m_count++;
 
 	unsigned int vertexSize = m_vertexFormat.getVertexSize();
-	uint8_t* oldIndicesPtr = !m_indices.empty() ? &m_indices.front() : nullptr;
+	const uint8_t* oldIndicesPtr = !m_indices.isEmpty() ? m_indices.getData() : nullptr;
 
 	if (m_pendingVertices > 0)
 	{
@@ -443,7 +444,7 @@ void Tesselator::vertex(float x, float y, float z)
 	m_indices.resize((m_vertices+1) * vertexSize);
 
 	// Make sure m_indices front pointer hasn't changed from reallocation as a result of reserve or resize
-	if (isFormatFixed() && oldIndicesPtr == &m_indices.front())
+	if (isFormatFixed() && oldIndicesPtr == m_indices.getData())
 	{
 		m_currentVertex.nextVertex();
 	}

--- a/source/client/renderer/renderer/Tesselator.cpp
+++ b/source/client/renderer/renderer/Tesselator.cpp
@@ -442,6 +442,7 @@ void Tesselator::vertex(float x, float y, float z)
 	}
 
 	bool didResize = m_indices.resize((m_vertices+1) * vertexSize);
+	(void)didResize; // to silence dumb warnings
 
 	// useful for finding improperly pre-allocated Tesselator calls, reducing these reduces memcpy calls,
 	// which provides SUBSTANTIAL performace gains

--- a/source/client/renderer/renderer/Tesselator.cpp
+++ b/source/client/renderer/renderer/Tesselator.cpp
@@ -437,11 +437,15 @@ void Tesselator::vertex(float x, float y, float z)
 
 	if (m_pendingVertices > 0)
 	{
-		m_indices.reserve(vertexSize * m_pendingVertices);
+		m_indices.reserve(m_pendingVertices * vertexSize);
 		m_pendingVertices = 0;
 	}
 
-	m_indices.resize((m_vertices+1) * vertexSize);
+	bool didResize = m_indices.resize((m_vertices+1) * vertexSize);
+
+	// useful for finding improperly pre-allocated Tesselator calls, reducing these reduces memcpy calls,
+	// which provides SUBSTANTIAL performace gains
+	//assert(!didResize);
 
 	// Make sure m_indices front pointer hasn't changed from reallocation as a result of reserve or resize
 	if (isFormatFixed() && oldIndicesPtr == m_indices.getData())

--- a/source/client/renderer/renderer/Tesselator.hpp
+++ b/source/client/renderer/renderer/Tesselator.hpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <vector>
 #include "common/math/Color.hpp"
+#include "common/utility/ByteBuffer.hpp"
 #include "client/renderer/RenderChunk.hpp"
 #include "renderer/VertexFormat.hpp"
 #include "renderer/hal/enums/PrimitiveMode.hpp"
@@ -106,7 +107,7 @@ public:
 private:
 	CurrentVertexPointers m_currentVertex;
 
-	std::vector<uint8_t> m_indices;
+	ByteBuffer m_indices;
 	bool m_bHasIndices;
 
 	uint8_t m_indexSize;

--- a/source/common/utility/ByteBuffer.cpp
+++ b/source/common/utility/ByteBuffer.cpp
@@ -1,4 +1,4 @@
-#include <utility>
+#include <algorithm>
 #include "ByteBuffer.hpp"
 
 const ByteBuffer ByteBuffer::EMPTY;

--- a/source/common/utility/ByteBuffer.cpp
+++ b/source/common/utility/ByteBuffer.cpp
@@ -37,6 +37,7 @@ void ByteBuffer::clear()
     }
 
     m_size = 0;
+    m_bIsOrphaned = false;
 }
 
 bool ByteBuffer::resize(size_t newSize)

--- a/source/common/utility/ByteBuffer.cpp
+++ b/source/common/utility/ByteBuffer.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstring>
 #include "ByteBuffer.hpp"
 
 const ByteBuffer ByteBuffer::EMPTY;

--- a/source/common/utility/ByteBuffer.cpp
+++ b/source/common/utility/ByteBuffer.cpp
@@ -9,6 +9,7 @@ ByteBuffer::ByteBuffer()
     m_data = nullptr;
     m_size = 0;
     m_bIsOrphaned = false;
+    m_bIsReference = false;
 }
 
 ByteBuffer::~ByteBuffer()
@@ -28,9 +29,22 @@ void ByteBuffer::_move(ByteBuffer& other)
     std::swap(this->m_size, other.m_size);
 }
 
+void ByteBuffer::assign(ByteBuffer& other)
+{
+    if (other.isOrphaned())
+    {
+        swap(other);
+        return;
+    }
+    
+    m_data = other.m_data;
+    m_size = other.m_size;
+    m_bIsReference = true;
+}
+
 void ByteBuffer::clear()
 {
-    if (m_data)
+    if (m_data && !m_bIsReference)
     {
         delete[] m_data;
         m_data = nullptr;
@@ -38,6 +52,7 @@ void ByteBuffer::clear()
 
     m_size = 0;
     m_bIsOrphaned = false;
+    m_bIsReference = false;
 }
 
 bool ByteBuffer::resize(size_t newSize)

--- a/source/common/utility/ByteBuffer.cpp
+++ b/source/common/utility/ByteBuffer.cpp
@@ -1,0 +1,67 @@
+#include <utility>
+#include "ByteBuffer.hpp"
+
+const ByteBuffer ByteBuffer::EMPTY;
+
+ByteBuffer::ByteBuffer()
+{
+    m_data = nullptr;
+    m_size = 0;
+    m_bIsOrphaned = false;
+}
+
+ByteBuffer::~ByteBuffer()
+{
+    clear();
+}
+
+void ByteBuffer::_init(ByteBuffer& other)
+{
+    _move(other);
+    clear();
+}
+
+void ByteBuffer::_move(ByteBuffer& other)
+{
+    std::swap(this->m_data, other.m_data);
+    std::swap(this->m_size, other.m_size);
+}
+
+void ByteBuffer::clear()
+{
+    if (m_data)
+    {
+        delete[] m_data;
+        m_data = nullptr;
+    }
+
+    m_size = 0;
+}
+
+void ByteBuffer::resize(size_t newSize)
+{
+    if (m_size >= newSize)
+        return;
+
+    /*if (m_size == newSize)
+        return;*/
+
+    uint8_t* newData = new uint8_t[newSize];
+
+    if (m_data)
+    {
+        memcpy(newData, m_data, m_size);
+        delete[] m_data;
+    }
+
+    m_data = newData;
+    m_size = newSize;
+}
+
+/*void ByteBuffer::reserve(size_t size)
+{
+    if (m_size >= size)
+        return;
+
+    resize(size);
+}*/

--- a/source/common/utility/ByteBuffer.cpp
+++ b/source/common/utility/ByteBuffer.cpp
@@ -39,13 +39,13 @@ void ByteBuffer::clear()
     m_size = 0;
 }
 
-void ByteBuffer::resize(size_t newSize)
+bool ByteBuffer::resize(size_t newSize)
 {
     if (m_size >= newSize)
-        return;
+        return false;
 
     /*if (m_size == newSize)
-        return;*/
+        return false;*/
 
     uint8_t* newData = new uint8_t[newSize];
 
@@ -57,6 +57,8 @@ void ByteBuffer::resize(size_t newSize)
 
     m_data = newData;
     m_size = newSize;
+
+    return true;
 }
 
 /*void ByteBuffer::reserve(size_t size)

--- a/source/common/utility/ByteBuffer.hpp
+++ b/source/common/utility/ByteBuffer.hpp
@@ -21,7 +21,8 @@ public:
 
 public:
 	void swap(ByteBuffer& other) { assert(other.isEmpty() || other.isOrphaned()); return _move(other); }
-
+    void assign(ByteBuffer& other);
+    
 	void clear();
 	bool resize(size_t newSize);
 	void reserve(size_t size) { resize(size); }
@@ -46,5 +47,6 @@ private:
 	uint8_t* m_data;
 	size_t m_size;
 	bool m_bIsOrphaned; // indicates whether or not the buffer has a parent or guardian
+    bool m_bIsReference;
 };
 

--- a/source/common/utility/ByteBuffer.hpp
+++ b/source/common/utility/ByteBuffer.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <stdint.h>
+#include <assert.h>
+#include "compat/LegacyCPP.hpp"
+
+// A "vector" willing to give up its memory
+class ByteBuffer
+{
+public:
+	static const ByteBuffer EMPTY;
+
+protected:
+	void _init(ByteBuffer& other);
+	void _move(ByteBuffer& other);
+
+public:
+	ByteBuffer();
+	~ByteBuffer();
+	MC_CTOR_MOVE_CUSTOM(ByteBuffer);
+
+public:
+	void swap(ByteBuffer& other) { assert(other.isEmpty() || other.isOrphaned()); return _move(other); }
+
+	void clear();
+	void resize(size_t newSize);
+	void reserve(size_t size) { resize(size); }
+
+	void orphan() { m_bIsOrphaned = true; }
+	void adopt() { m_bIsOrphaned = false; }
+	bool isOrphaned() const { return m_bIsOrphaned; }
+
+	uint8_t*& data() { return m_data; }
+	const uint8_t* getData() const { return m_data; }
+
+	size_t getSize() const { return m_size; }
+	bool isEmpty() const { return m_size == 0; }
+
+public:
+	MC_FUNC_MOVE(ByteBuffer);
+	uint8_t& operator[](size_t index) { return m_data[index]; }
+	const uint8_t& operator[](size_t index) const { return m_data[index]; }
+	operator bool() const { return m_data != nullptr; }
+
+private:
+	uint8_t* m_data;
+	size_t m_size;
+	bool m_bIsOrphaned; // indicates whether or not the buffer has a parent or guardian
+};
+

--- a/source/common/utility/ByteBuffer.hpp
+++ b/source/common/utility/ByteBuffer.hpp
@@ -23,7 +23,7 @@ public:
 	void swap(ByteBuffer& other) { assert(other.isEmpty() || other.isOrphaned()); return _move(other); }
 
 	void clear();
-	void resize(size_t newSize);
+	bool resize(size_t newSize);
 	void reserve(size_t size) { resize(size); }
 
 	void orphan() { m_bIsOrphaned = true; }

--- a/source/renderer/Mesh.cpp
+++ b/source/renderer/Mesh.cpp
@@ -13,10 +13,10 @@ Mesh::Mesh()
     m_vertexCount = 0;
     m_primitiveMode = PRIMITIVE_MODE_NONE;
     m_indexSize = 0;
-    m_rawData = nullptr;
+    m_pRawData = nullptr;
 }
 
-Mesh::Mesh(const VertexFormat& vertexFormat, unsigned int vertexCount, unsigned int indexCount, uint8_t indexSize, PrimitiveMode primitiveMode, uint8_t *data, bool temporary)
+Mesh::Mesh(const VertexFormat& vertexFormat, unsigned int vertexCount, unsigned int indexCount, uint8_t indexSize, PrimitiveMode primitiveMode, ByteBuffer& data, bool temporary)
     : m_indexCount(indexCount)
     , m_vertexCount(vertexCount)
     , m_primitiveMode(primitiveMode)
@@ -25,11 +25,12 @@ Mesh::Mesh(const VertexFormat& vertexFormat, unsigned int vertexCount, unsigned 
 {
     if (temporary)
     {
-        m_rawData = data;
+        m_pRawData = &data;
+        //data = nullptr; // @NOTE: NOT SAFE
     }
     else
     {
-        m_rawData = nullptr;
+        m_pRawData = nullptr;
         if (!loadRawData(RenderContextImmediate::get(), data))
         {
             assert(false);
@@ -52,7 +53,7 @@ void Mesh::_move(Mesh& other)
     this->m_indexCount = other.m_indexCount;
     this->m_indexSize = other.m_indexSize;
     this->m_primitiveMode = other.m_primitiveMode;
-    this->m_rawData = other.m_rawData;
+    this->m_pRawData = other.m_pRawData;
 
     other.m_vertexFormat = VertexFormat::EMPTY;
     other.m_indexCount = 0;
@@ -68,10 +69,10 @@ void Mesh::reset()
     m_primitiveMode = PRIMITIVE_MODE_NONE;
     m_vertexFormat = VertexFormat::EMPTY;
     m_indexSize = 0;
-    m_rawData = nullptr;
+    m_pRawData = nullptr;
 }
 
-bool Mesh::loadRawData(RenderContext& context, uint8_t *data)
+bool Mesh::loadRawData(RenderContext& context, ByteBuffer& data)
 {
     if (!data)
         return false;
@@ -81,17 +82,23 @@ bool Mesh::loadRawData(RenderContext& context, uint8_t *data)
         return false;
     if (!m_vertexFormat)
         return false;
+
+    data.orphan(); // orphan so the vertex buffer can take ownership
     
     unsigned int vertexSize = m_vertexFormat.getVertexSize();
     m_vertexBuffer.createVertexBuffer(context, vertexSize, data, m_vertexCount);
 
-    if (m_indexCount == 0)
+    assert(m_indexCount == 0);
+    return true;
+
+    /*if (m_indexCount == 0)
         return true;
 
     unsigned int index = m_vertexCount * vertexSize;
-    m_indexBuffer.createIndexBuffer(context, m_indexSize, &data[index], m_indexCount);
+    void* indices = &data[index]; // @TODO: this will not work since the vertex buffer will take ownership of the ByteBuffer
+    m_indexBuffer.createIndexBuffer(context, m_indexSize, indices, m_indexCount);
 
-    return true;
+    return true;*/
 }
 
 void Mesh::render(const MaterialPtr& materialPtr, unsigned int startOffset, unsigned int count)
@@ -109,13 +116,13 @@ void Mesh::render(const MaterialPtr& materialPtr, unsigned int startOffset, unsi
 
         if (!immediateBuffer.isValid())
         {
+            ByteBuffer nothing;
             // Create 1Mb shared vertex buffer in VRAM
-            immediateBuffer.createDynamicBuffer(context, 1, nullptr, 0x100000, BUFFER_TYPE_VERTEX);
+            immediateBuffer.createDynamicBuffer(context, 1, nothing, 0x100000, BUFFER_TYPE_VERTEX);
         }
 
         unsigned int vertexSize = m_vertexFormat.getVertexSize();
-        void* vertexData = m_rawData;
-        immediateBuffer.updateBuffer(context, vertexSize, vertexData, vertexCount);
+        immediateBuffer.updateBuffer(context, vertexSize, *m_pRawData, vertexCount);
     }
     else
     {
@@ -127,7 +134,7 @@ void Mesh::render(const MaterialPtr& materialPtr, unsigned int startOffset, unsi
 
     if (materialPtr)
     {
-        materialPtr->useWith(context, m_vertexFormat, m_rawData);
+        materialPtr->useWith(context, m_vertexFormat, m_pRawData);
 #ifdef FEATURE_GFX_SHADERS
         materialPtr->m_pShader->validateVertexFormat(m_vertexFormat);
 #endif
@@ -174,7 +181,7 @@ bool Mesh::isValid() const
 
 bool Mesh::isTemporary() const
 {
-    return m_rawData != nullptr;
+    return m_pRawData != nullptr;
 }
 
 void Mesh::clearGlobalBuffers()

--- a/source/renderer/Mesh.hpp
+++ b/source/renderer/Mesh.hpp
@@ -18,12 +18,12 @@ namespace mce
         uint8_t m_indexSize;
         Buffer m_vertexBuffer;
         Buffer m_indexBuffer;
-        void *m_rawData;
+        ByteBuffer* m_pRawData;
 
     public:
         Mesh();
         MC_CTOR_MOVE(Mesh);
-        Mesh(const VertexFormat& vertexFormat, unsigned int vertexCount, unsigned int indexCount, uint8_t indexSize, PrimitiveMode primitiveMode, uint8_t *data, bool temporary);
+        Mesh(const VertexFormat& vertexFormat, unsigned int vertexCount, unsigned int indexCount, uint8_t indexSize, PrimitiveMode primitiveMode, ByteBuffer& data, bool temporary);
         ~Mesh();
 
     protected:
@@ -31,7 +31,7 @@ namespace mce
 
     public:
         void reset();
-        bool loadRawData(RenderContext& context, uint8_t *data);
+        bool loadRawData(RenderContext& context, ByteBuffer& data);
         void render(const MaterialPtr& materialPtr, unsigned int startOffset = 0, unsigned int count = 0);
         bool isValid() const;
         bool isTemporary() const;

--- a/source/renderer/QuadIndexBuffer.cpp
+++ b/source/renderer/QuadIndexBuffer.cpp
@@ -1,7 +1,7 @@
 #include <stdint.h>
-#include <vector>
 #include <typeinfo>
 #include "QuadIndexBuffer.hpp"
+#include "common/utility/ByteBuffer.hpp"
 #include "RenderContextImmediate.hpp"
 
 using namespace mce;
@@ -27,7 +27,7 @@ void QuadIndexBuffer::onAppSuspended()
 }
 
 template <typename T>
-void _makeIndexBuffer(std::vector<uint8_t>& indices, unsigned int vertexCount)
+void _makeIndexBuffer(ByteBuffer& indices, unsigned int vertexCount)
 {
     constexpr unsigned int indexSize = sizeof(T) * 6;
     const unsigned int quadCount = vertexCount / 4;
@@ -68,7 +68,7 @@ Buffer& QuadIndexBuffer::getGlobalQuadBuffer(RenderContext& context, unsigned in
     while (m_capacity < requiredCapacity)
         m_capacity *= 2;
 
-    std::vector<uint8_t> indices;
+    ByteBuffer indices; // m_globalBuffer either takes ownership of this or it doesn't, either way, it doesn't dangle
     const mce::RenderContext& renderContext = mce::RenderContextImmediate::getAsConst();
 
     // Use 16-bit indices for smaller buffers to save memory, otherwise use 32-bit.
@@ -83,12 +83,12 @@ Buffer& QuadIndexBuffer::getGlobalQuadBuffer(RenderContext& context, unsigned in
         _makeIndexBuffer<uint32_t>(indices, m_capacity);
     }
 
-    void* data = &indices[0];
+    indices.orphan(); // orphan so the m_globalBuffer can adopt it
 
     m_globalBuffer.releaseBuffer();
 
-    m_globalBuffer.createDynamicIndexBuffer(context, m_indexSize, indices.size());
-    m_globalBuffer.updateBuffer(context, m_indexSize, data, indices.size() / m_indexSize);
+    m_globalBuffer.createDynamicIndexBuffer(context, m_indexSize, indices.getSize());
+    m_globalBuffer.updateBuffer(context, m_indexSize, indices, indices.getSize() / m_indexSize);
 
     outIndexSize = m_indexSize;
     return m_globalBuffer;

--- a/source/renderer/hal/base/BufferBase.cpp
+++ b/source/renderer/hal/base/BufferBase.cpp
@@ -31,7 +31,7 @@ void BufferBase::_init(BufferBase& other)
 
 void BufferBase::_move(BufferBase& other)
 {
-    std::swap(this->m_clientBuffer, other.m_clientBuffer);
+    this->m_clientBuffer = other.m_clientBuffer; // forces a swap
     std::swap(this->m_bufferType, other.m_bufferType);
     std::swap(this->m_stride, other.m_stride);
     std::swap(this->m_count, other.m_count);

--- a/source/renderer/hal/base/BufferBase.cpp
+++ b/source/renderer/hal/base/BufferBase.cpp
@@ -86,8 +86,9 @@ void BufferBase::_updateClientBuffer(RenderContext& context, unsigned int stride
 
     assert(m_bufferOffset == 0);
     assert(!data.isEmpty());
-
-    m_clientBuffer.swap(data);
+    
+    m_clientBuffer.assign(data);
+    
     m_internalSize = size;
 
     /*if (size <= m_internalSize)

--- a/source/renderer/hal/base/BufferBase.cpp
+++ b/source/renderer/hal/base/BufferBase.cpp
@@ -9,7 +9,8 @@ using namespace mce;
 
 BufferBase::BufferBase()
 {
-    m_clientData = nullptr;
+    //m_clientData = nullptr;
+    //m_bOwnsData = true;
     m_internalSize = 0;
     m_bufferOffset = 0;
     
@@ -30,7 +31,7 @@ void BufferBase::_init(BufferBase& other)
 
 void BufferBase::_move(BufferBase& other)
 {
-    std::swap(this->m_clientData, other.m_clientData);
+    std::swap(this->m_clientBuffer, other.m_clientBuffer);
     std::swap(this->m_bufferType, other.m_bufferType);
     std::swap(this->m_stride, other.m_stride);
     std::swap(this->m_count, other.m_count);
@@ -38,62 +39,76 @@ void BufferBase::_move(BufferBase& other)
     std::swap(this->m_bufferOffset, other.m_bufferOffset);
 }
 
-void BufferBase::_createClientBuffer(RenderContext& context, const void* data, BufferType bufferType)
+void BufferBase::_createClientBuffer(RenderContext& context, ByteBuffer& data, BufferType bufferType)
 {
-    assert(m_clientData == nullptr);
-    m_clientData = new int8_t[m_internalSize];
+    assert(m_clientBuffer.isEmpty());
+
     if (data)
-        memcpy(m_clientData, data, m_internalSize);
+    {
+        m_clientBuffer.swap(data);
+    }
+    else
+    {
+        m_clientBuffer.reserve(m_internalSize);
+    }
 
     _bindClientBuffer(context);
 }
 
 void BufferBase::_bindClientBuffer(RenderContext& context)
 {
-    assert(m_clientData != nullptr);
+    assert(!m_clientBuffer.isEmpty());
     void*& activeBuffer = context.getActiveClientBuffer(m_bufferType);
-    if (activeBuffer == m_clientData)
+    if (activeBuffer == m_clientBuffer.getData())
         return;
 
-    activeBuffer = m_clientData;
+    activeBuffer = (void*)m_clientBuffer.getData();
 }
 
-void BufferBase::_resizeClientBuffer(RenderContext& context, const void* data, unsigned int size)
+void BufferBase::_resizeClientBuffer(RenderContext& context, ByteBuffer& data, unsigned int size)
 {
-    if (m_clientData)
-        delete[] m_clientData;
+    if (data)
+    {
+        m_clientBuffer.swap(data);
+    }
+    else
+    {
+        //memcpy(newBuffer, data, size);
+        m_clientBuffer.reserve(m_internalSize);
+    }
 
-    int8_t* newBuffer = new int8_t[size];
-    memcpy(newBuffer, data, size);
-
-    m_clientData = newBuffer;
     m_internalSize = size;
 }
 
-void BufferBase::_updateClientBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count)
+void BufferBase::_updateClientBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count)
 {
     const unsigned int size = count * stride;
 
-    if (size <= m_internalSize)
+    assert(m_bufferOffset == 0);
+    assert(!data.isEmpty());
+
+    m_clientBuffer.swap(data);
+    m_internalSize = size;
+
+    /*if (size <= m_internalSize)
+    {
         memcpy(m_clientData, (int8_t*)data + m_bufferOffset, size);
+    }
     else
+    {
         _resizeClientBuffer(context, data, size);
+    }*/
 }
 
 void BufferBase::releaseBuffer()
 {
-    if (m_clientData)
-    {
-        delete[] m_clientData;
-        m_clientData = nullptr;
-    }
-
+    m_clientBuffer.clear();
     m_stride = 0;
     m_bufferType = BUFFER_TYPE_NONE;
     m_count = 0;
 }
 
-void BufferBase::createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType)
+void BufferBase::createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     m_stride = stride;
     m_count = count;
@@ -101,12 +116,12 @@ void BufferBase::createBuffer(RenderContext& context, unsigned int stride, const
     m_bufferType = bufferType;
 }
 
-void BufferBase::createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType)
+void BufferBase::createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     createBuffer(context, stride, data, count, bufferType);
 }
 
-void BufferBase::updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count)
+void BufferBase::updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count)
 {
     m_stride = stride;
     m_count = count;

--- a/source/renderer/hal/base/BufferBase.hpp
+++ b/source/renderer/hal/base/BufferBase.hpp
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "compat/LegacyCPP.hpp"
+#include "common/utility/ByteBuffer.hpp"
 #include "renderer/hal/enums/BufferType.hpp"
 
 namespace mce
@@ -11,7 +12,7 @@ namespace mce
 	class BufferBase
 	{
 	public:
-        int8_t* m_clientData;
+        ByteBuffer m_clientBuffer;
         BufferType m_bufferType;
         unsigned int m_stride;
         unsigned int m_count;
@@ -21,11 +22,11 @@ namespace mce
 	protected:
 		void _init(BufferBase& other);
 		void _move(BufferBase& other);
-        void _createClientBuffer(RenderContext& context, const void* data, BufferType bufferType);
+        void _createClientBuffer(RenderContext& context, ByteBuffer& data, BufferType bufferType);
         void _bindClientBuffer(RenderContext& context);
-        void _resizeClientBuffer(RenderContext& context, const void* data, unsigned int size);
-        void _updateClientBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count);
-        bool _isClientBuffer() const { return m_clientData != nullptr; }
+        void _resizeClientBuffer(RenderContext& context, ByteBuffer& data, unsigned int size);
+        void _updateClientBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count);
+        bool _isClientBuffer() const { return !m_clientBuffer.isEmpty(); }
 
 	public:
         BufferBase();
@@ -34,10 +35,10 @@ namespace mce
 
         void releaseBuffer();
         void bindBuffer(RenderContext& context) {}
-		void createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType);
-		void createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType);
-        void resizeBuffer(RenderContext& context, const void* data, unsigned int size) {}
-        void updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count);
+		void createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+		void createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+        void resizeBuffer(RenderContext& context, ByteBuffer& data, unsigned int size) {}
+        void updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count);
 		void copy(BufferBase& other);
         unsigned int getInternalBufferSize() const { return m_internalSize; }
         bool isValid() const { return m_internalSize > 0; }

--- a/source/renderer/hal/base/RenderContextBase.cpp
+++ b/source/renderer/hal/base/RenderContextBase.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <stdexcept>
 #include "RenderContextBase.hpp"
 
 using namespace mce;

--- a/source/renderer/hal/d3d11/BufferD3D11.cpp
+++ b/source/renderer/hal/d3d11/BufferD3D11.cpp
@@ -41,7 +41,7 @@ BufferD3D11::~BufferD3D11()
     releaseBuffer();
 }
 
-void BufferD3D11::_createBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType, bool isDynamic)
+void BufferD3D11::_createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType, bool isDynamic)
 {
     if (m_buffer)
     {
@@ -133,25 +133,25 @@ void BufferD3D11::bindBuffer(RenderContext& context)
     }
 }
 
-void BufferD3D11::createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType)
+void BufferD3D11::createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     _createBuffer(context, stride, data, count, bufferType, false);
     BufferBase::createBuffer(context, stride, data, count, bufferType);
 }
 
-void BufferD3D11::createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType)
+void BufferD3D11::createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     _createBuffer(context, stride, data, count, bufferType, true);
     BufferBase::createDynamicBuffer(context, stride, data, count, bufferType);
 }
 
-void BufferD3D11::resizeBuffer(RenderContext& context, const void* data, unsigned int size)
+void BufferD3D11::resizeBuffer(RenderContext& context, ByteBuffer& data, unsigned int size)
 {
     LOG_E("BufferD3D11::resizeBuffer() not implemented");
     throw std::bad_cast();
 }
 
-void BufferD3D11::updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count, MapType mapType)
+void BufferD3D11::updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, MapType mapType)
 {
     D3D11_MAPPED_SUBRESOURCE subResource;
     D3DDeviceContext d3dDeviceContext = context.getD3DDeviceContext();

--- a/source/renderer/hal/d3d11/BufferD3D11.cpp
+++ b/source/renderer/hal/d3d11/BufferD3D11.cpp
@@ -176,7 +176,7 @@ void BufferD3D11::updateBuffer(RenderContext& context, unsigned int stride, Byte
     }
     else
     {
-        memcpy((int8_t*)subResource.pData + m_bufferOffset, data, stride * count);
+        memcpy((int8_t*)subResource.pData + m_bufferOffset, data.getData(), stride * count);
         d3dDeviceContext->Unmap(**m_buffer, 0);
     }
         

--- a/source/renderer/hal/d3d11/BufferD3D11.cpp
+++ b/source/renderer/hal/d3d11/BufferD3D11.cpp
@@ -78,7 +78,7 @@ void BufferD3D11::_createBuffer(RenderContext& context, unsigned int stride, Byt
     {
         subResourceData.SysMemPitch = 0;
         subResourceData.SysMemSlicePitch = 0;
-        subResourceData.pSysMem = data;
+        subResourceData.pSysMem = data.getData();
     }
 
     D3DDevice d3dDevice = context.getD3DDevice();

--- a/source/renderer/hal/d3d11/BufferD3D11.hpp
+++ b/source/renderer/hal/d3d11/BufferD3D11.hpp
@@ -19,16 +19,16 @@ namespace mce
         ~BufferD3D11();
 
     protected:
-        void _createBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType, bool isDynamic);
+        void _createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType, bool isDynamic);
 
     public:
 		void _move(BufferD3D11& other);
         void releaseBuffer();
         void bindBuffer(RenderContext& context);
-		void createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType);
-		void createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType);
-        void resizeBuffer(RenderContext& context, const void* data, unsigned int size);
-        void updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count, MapType mapType = MAP_WRITE_DISCARD);
+		void createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+		void createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+        void resizeBuffer(RenderContext& context, ByteBuffer& data, unsigned int size);
+        void updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, MapType mapType = MAP_WRITE_DISCARD);
         bool isValid() const { return m_buffer; }
 
         MC_FUNC_MOVE(BufferD3D11);

--- a/source/renderer/hal/d3d11/ImmediateBufferD3D11.cpp
+++ b/source/renderer/hal/d3d11/ImmediateBufferD3D11.cpp
@@ -11,12 +11,12 @@ ImmediateBufferD3D11::ImmediateBufferD3D11()
 {
 }
 
-void ImmediateBufferD3D11::createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType)
+void ImmediateBufferD3D11::createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     BufferD3D11::createDynamicBuffer(context, stride, data, count, bufferType);
 }
 
-void ImmediateBufferD3D11::updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count)
+void ImmediateBufferD3D11::updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count)
 {
     MapType mapType = MAP_WRITE_NO_OVERWRITE;
 

--- a/source/renderer/hal/d3d11/ImmediateBufferD3D11.hpp
+++ b/source/renderer/hal/d3d11/ImmediateBufferD3D11.hpp
@@ -12,8 +12,8 @@ namespace mce
         ImmediateBufferD3D11();
 
     public:
-        void createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType);
-        void updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count);
+        void createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+        void updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count);
 
         bool isValid() const;
     };

--- a/source/renderer/hal/d3d9/BufferD3D9.cpp
+++ b/source/renderer/hal/d3d9/BufferD3D9.cpp
@@ -97,8 +97,7 @@ void BufferD3D9::_createBuffer(RenderContext& context, unsigned int stride, Byte
 
     if (data)
     {
-        void* pData = (void*)data;
-        updateBuffer(context, stride, pData, count);
+        updateBuffer(context, stride, data, count);
     }
 }
 
@@ -187,7 +186,7 @@ void BufferD3D9::updateBuffer(RenderContext& context, unsigned int stride, ByteB
     }
 
     // 360 requires that we lock the entire buffer
-    memcpy((int8_t*)pData + m_bufferOffset, data, stride * count);
+    memcpy((int8_t*)pData + m_bufferOffset, data.getData(), stride * count);
  
     switch (m_bufferType)
     {

--- a/source/renderer/hal/d3d9/BufferD3D9.cpp
+++ b/source/renderer/hal/d3d9/BufferD3D9.cpp
@@ -49,7 +49,7 @@ BufferD3D9::~BufferD3D9()
     releaseBuffer();
 }
 
-void BufferD3D9::_createBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType, bool isDynamic)
+void BufferD3D9::_createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType, bool isDynamic)
 {
     D3DDevice d3dDevice = context.getD3DDevice();
     DWORD usage = isDynamic ? D3DUSAGE_DYNAMIC : 0x0;
@@ -143,25 +143,25 @@ void BufferD3D9::bindBuffer(RenderContext& context)
     }
 }
 
-void BufferD3D9::createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType)
+void BufferD3D9::createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     BufferBase::createBuffer(context, stride, data, count, bufferType);
     _createBuffer(context, stride, data, count, bufferType, false);
 }
 
-void BufferD3D9::createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType)
+void BufferD3D9::createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     BufferBase::createDynamicBuffer(context, stride, data, count, bufferType);
     _createBuffer(context, stride, data, count, bufferType, true);
 }
 
-void BufferD3D9::resizeBuffer(RenderContext& context, const void* data, unsigned int size)
+void BufferD3D9::resizeBuffer(RenderContext& context, ByteBuffer& data, unsigned int size)
 {
     LOG_E("BufferD3D9::resizeBuffer() not implemented");
     throw std::bad_cast();
 }
 
-void BufferD3D9::updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count, MapType mapType)
+void BufferD3D9::updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, MapType mapType)
 {
     if (m_internalSize < stride * count)
     {

--- a/source/renderer/hal/d3d9/BufferD3D9.hpp
+++ b/source/renderer/hal/d3d9/BufferD3D9.hpp
@@ -20,16 +20,16 @@ namespace mce
         ~BufferD3D9();
 
     protected:
-        void _createBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType, bool isDynamic);
+        void _createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType, bool isDynamic);
 
     public:
 		void _move(BufferD3D9& other);
         void releaseBuffer();
         void bindBuffer(RenderContext& context);
-		void createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType);
-		void createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType);
-        void resizeBuffer(RenderContext& context, const void* data, unsigned int size);
-        void updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count, MapType mapType = MAP_WRITE_DISCARD);
+		void createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+		void createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+        void resizeBuffer(RenderContext& context, ByteBuffer& data, unsigned int size);
+        void updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, MapType mapType = MAP_WRITE_DISCARD);
         bool isValid() const { return m_vertexBuffer || m_indexBuffer; }
 
         MC_FUNC_MOVE(BufferD3D9);

--- a/source/renderer/hal/d3d9/ImmediateBufferD3D9.cpp
+++ b/source/renderer/hal/d3d9/ImmediateBufferD3D9.cpp
@@ -25,14 +25,14 @@ void ImmediateBufferD3D9::_swapBuffers()
     m_pBuffer = m_pBuffer == &m_buffer1 ? &m_buffer2 : &m_buffer1;
 }
 
-void ImmediateBufferD3D9::createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType)
+void ImmediateBufferD3D9::createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     // We're eating 2 MBs here instead of one
     m_buffer1.createDynamicBuffer(context, stride, data, count, bufferType);
     m_buffer2.createDynamicBuffer(context, stride, data, count, bufferType);
 }
 
-void ImmediateBufferD3D9::updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count)
+void ImmediateBufferD3D9::updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count)
 {
     // @NOTE: We do our own double-buffering because the 360 will shit itself otherwise and read the wrong vertex data
     _swapBuffers();

--- a/source/renderer/hal/d3d9/ImmediateBufferD3D9.hpp
+++ b/source/renderer/hal/d3d9/ImmediateBufferD3D9.hpp
@@ -24,8 +24,8 @@ namespace mce
         void _swapBuffers();
 
     public:
-        void createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType);
-        void updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count);
+        void createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+        void updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count);
         bool isValid() const;
 
         MC_FUNC_MOVE(ImmediateBufferD3D9);

--- a/source/renderer/hal/interface/Buffer.cpp
+++ b/source/renderer/hal/interface/Buffer.cpp
@@ -5,22 +5,24 @@
 
 using namespace mce;
 
-void Buffer::createIndexBuffer(RenderContext& context, unsigned int sizeOfSingleIndice, const void *indices, unsigned int numberOfIndices)
+void Buffer::createIndexBuffer(RenderContext& context, unsigned int sizeOfSingleIndice, ByteBuffer& indices, unsigned int numberOfIndices)
 {
     createBuffer(context, sizeOfSingleIndice, indices, numberOfIndices, BUFFER_TYPE_INDEX);
 }
 
-void Buffer::createVertexBuffer(RenderContext& context, unsigned int vertexStride, const void *vertices, unsigned int numberOfVertices)
+void Buffer::createVertexBuffer(RenderContext& context, unsigned int vertexStride, ByteBuffer& vertices, unsigned int numberOfVertices)
 {
     createBuffer(context, vertexStride, vertices, numberOfVertices, BUFFER_TYPE_VERTEX);
 }
 
 void Buffer::createDynamicIndexBuffer(RenderContext& context, unsigned int stride, unsigned int count)
 {
-    createDynamicBuffer(context, stride, nullptr, count, BUFFER_TYPE_INDEX);
+    ByteBuffer nothing;
+    createDynamicBuffer(context, stride, nothing, count, BUFFER_TYPE_INDEX);
 }
 
 void Buffer::createDynamicVertexBuffer(RenderContext& context, unsigned int stride, unsigned int count)
 {
-    createDynamicBuffer(context, stride, nullptr, count, BUFFER_TYPE_VERTEX);
+    ByteBuffer nothing;
+    createDynamicBuffer(context, stride, nothing, count, BUFFER_TYPE_VERTEX);
 }

--- a/source/renderer/hal/interface/Buffer.hpp
+++ b/source/renderer/hal/interface/Buffer.hpp
@@ -8,8 +8,8 @@ namespace mce
     class Buffer : public MCE_GFX_CLASS(Buffer)
     {
     public:
-        void createIndexBuffer(RenderContext& context, unsigned int sizeOfSingleIndice, const void *indices, unsigned int numberOfIndices);
-        void createVertexBuffer(RenderContext& context, unsigned int vertexStride, const void *vertices, unsigned int numberOfVertices);
+        void createIndexBuffer(RenderContext& context, unsigned int sizeOfSingleIndice, ByteBuffer& indices, unsigned int numberOfIndices);
+        void createVertexBuffer(RenderContext& context, unsigned int vertexStride, ByteBuffer& vertices, unsigned int numberOfVertices);
         void createDynamicIndexBuffer(RenderContext& context, unsigned int stride, unsigned int count);
         void createDynamicVertexBuffer(RenderContext& context, unsigned int stride, unsigned int count);
 

--- a/source/renderer/hal/ogl/API_OGL.cpp
+++ b/source/renderer/hal/ogl/API_OGL.cpp
@@ -212,8 +212,7 @@ bool gl::supports16BitUnsignedUVs()
 
 bool gl::supportsServerBuffers()
 {
-    return false;
-    /*static int isSupported = -1;
+    static int isSupported = -1;
     if (isSupported < 0)
     {
         const gl::Version& glVersion = gl::Version::singleton();
@@ -226,5 +225,5 @@ bool gl::supportsServerBuffers()
             )
             isSupported = 1;
     }
-    return isSupported == 1;*/
+    return isSupported == 1;
 }

--- a/source/renderer/hal/ogl/API_OGL.cpp
+++ b/source/renderer/hal/ogl/API_OGL.cpp
@@ -212,7 +212,8 @@ bool gl::supports16BitUnsignedUVs()
 
 bool gl::supportsServerBuffers()
 {
-    static int isSupported = -1;
+    return false;
+    /*static int isSupported = -1;
     if (isSupported < 0)
     {
         const gl::Version& glVersion = gl::Version::singleton();
@@ -225,5 +226,5 @@ bool gl::supportsServerBuffers()
             )
             isSupported = 1;
     }
-    return isSupported == 1;
+    return isSupported == 1;*/
 }

--- a/source/renderer/hal/ogl/BufferOGL.cpp
+++ b/source/renderer/hal/ogl/BufferOGL.cpp
@@ -32,7 +32,7 @@ BufferOGL::~BufferOGL()
     releaseBuffer();
 }
 
-void BufferOGL::_createBuffer(RenderContext& context, const void* data, BufferType bufferType)
+void BufferOGL::_createBuffer(RenderContext& context, ByteBuffer& data, BufferType bufferType)
 {
     // catch any uncaught errors
     ErrorHandlerOGL::checkForErrors();
@@ -54,7 +54,7 @@ void BufferOGL::_createBuffer(RenderContext& context, const void* data, BufferTy
     activeBuffer = m_bufferName;
 
     // Creates and initializes the buffer object's data store
-    xglBufferData(m_target, m_internalSize, data, m_usage);
+    xglBufferData(m_target, m_internalSize, data.getData(), m_usage);
 
     ErrorHandlerOGL::checkForErrors();
 }
@@ -111,7 +111,7 @@ void BufferOGL::bindBuffer(RenderContext& context)
     activeBuffer = m_bufferName;
 }
 
-void BufferOGL::createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType)
+void BufferOGL::createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     BufferBase::createBuffer(context, stride, data, count, bufferType);
     
@@ -119,7 +119,7 @@ void BufferOGL::createBuffer(RenderContext& context, unsigned int stride, const 
     _createBuffer(context, data, bufferType);
 }
 
-void BufferOGL::createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType)
+void BufferOGL::createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     BufferBase::createDynamicBuffer(context, stride, data, count, bufferType);
 
@@ -132,7 +132,7 @@ void BufferOGL::createDynamicBuffer(RenderContext& context, unsigned int stride,
     _createBuffer(context, data, bufferType);
 }
 
-void BufferOGL::resizeBuffer(RenderContext& context, const void* data, unsigned int size)
+void BufferOGL::resizeBuffer(RenderContext& context, ByteBuffer& data, unsigned int size)
 {
     if (_isClientBuffer())
     {
@@ -141,11 +141,11 @@ void BufferOGL::resizeBuffer(RenderContext& context, const void* data, unsigned 
     }
 
     // @TODO: this can get called without bindBuffer being called first
-    xglBufferData(m_target, size, data, m_usage);
+    xglBufferData(m_target, size, data.getData(), m_usage);
     m_internalSize = size;
 }
 
-void BufferOGL::updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count)
+void BufferOGL::updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count)
 {
     if (_isClientBuffer())
     {
@@ -172,7 +172,7 @@ void BufferOGL::updateBuffer(RenderContext& context, unsigned int stride, void*&
         const unsigned int size = count * stride;
 
         if (!GLES1_WORKAROUND && size <= m_internalSize)
-            xglBufferSubData(m_target, m_bufferOffset, size, data);
+            xglBufferSubData(m_target, m_bufferOffset, size, data.getData());
         else
             resizeBuffer(context, data, size);
     }

--- a/source/renderer/hal/ogl/BufferOGL.hpp
+++ b/source/renderer/hal/ogl/BufferOGL.hpp
@@ -20,17 +20,17 @@ namespace mce
         ~BufferOGL();
 
     protected:
-        void _createBuffer(RenderContext& context, const void* data, BufferType bufferType);
+        void _createBuffer(RenderContext& context, ByteBuffer& data, BufferType bufferType);
 
     public:
 		void _move(BufferOGL& other);
         void releaseBuffer();
         void bindBuffer(RenderContext& context);
-		void createBuffer(RenderContext& context, unsigned int stride, const void *data, unsigned int count, BufferType bufferType);
-		void createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType);
-        void resizeBuffer(RenderContext& context, const void* data, unsigned int size);
-        void updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count);
-        bool isValid() const { return m_bufferName != GL_NONE || m_clientData != nullptr; }
+		void createBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+		void createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+        void resizeBuffer(RenderContext& context, ByteBuffer& data, unsigned int size);
+        void updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count);
+        bool isValid() const { return m_bufferName != GL_NONE || !m_clientBuffer.isEmpty(); }
 
         MC_FUNC_MOVE(BufferOGL);
 	};

--- a/source/renderer/hal/ogl/ImmediateBufferOGL.cpp
+++ b/source/renderer/hal/ogl/ImmediateBufferOGL.cpp
@@ -11,7 +11,7 @@ ImmediateBufferOGL::ImmediateBufferOGL()
 {
 }
 
-void ImmediateBufferOGL::createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType)
+void ImmediateBufferOGL::createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType)
 {
     if (gl::supportsImmediateMode())
     {
@@ -24,7 +24,7 @@ void ImmediateBufferOGL::createDynamicBuffer(RenderContext& context, unsigned in
     }
 }
 
-void ImmediateBufferOGL::updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count)
+void ImmediateBufferOGL::updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count)
 {
     if (gl::supportsImmediateMode())
     {

--- a/source/renderer/hal/ogl/ImmediateBufferOGL.hpp
+++ b/source/renderer/hal/ogl/ImmediateBufferOGL.hpp
@@ -12,8 +12,8 @@ namespace mce
         ImmediateBufferOGL();
 
     public:
-        void createDynamicBuffer(RenderContext& context, unsigned int stride, const void* data, unsigned int count, BufferType bufferType);
-        void updateBuffer(RenderContext& context, unsigned int stride, void*& data, unsigned int count);
+        void createDynamicBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count, BufferType bufferType);
+        void updateBuffer(RenderContext& context, unsigned int stride, ByteBuffer& data, unsigned int count);
         
         bool isValid() const { return BufferOGL::isValid(); } // { return m_target != GL_NONE; }
     };


### PR DESCRIPTION
* Added ByteBuffer. This removes unnecessary copying of data when using client-sided buffers for rendering.
* Fixed multiple bad Tesselator vertex buffer pre-allocations, noticeably improving performance for all devices, and greatly improving performance on pre-1.4 OpenGL versions.