### PR TITLE
GNU Makefile build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFLAGS := -O2 -DNDEBUG
 CXXFLAGS := -O2 -DNDEBUG
 
 DEFINES := -DHANDLE_CHARS_SEPARATELY -DRAPIDJSON_NO_THREAD_LOCAL -DSTBI_NO_THREAD_LOCALS
-INCLUDES := -I. -Isource -Ithirdparty -Ithirdparty/zlib -Ithirdparty/raknet -Ithirdparty/rapidjson -Ithirdparty/stb_image/include
+INCLUDES := -I. -Isource -Ithirdparty/zlib -Ithirdparty/raknet -Ithirdparty/rapidjson -Ithirdparty/stb_image/include
 
 C_SRCS := $(wildcard thirdparty/zlib/*.c) thirdparty/stb_image/src/stb_image_impl.c thirdparty/stb_image/include/stb_vorbis.c
 CXX_SRCS := $(shell find source \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,93 @@
+# Makefile build
+# meant to be extremely portable to weird unix-like systems
+
+CC := cc
+CXX := c++
+AR := ar
+
+CFLAGS := -O2 -DNDEBUG
+CXXFLAGS := -O2 -DNDEBUG
+
+DEFINES := -DHANDLE_CHARS_SEPARATELY -DRAPIDJSON_NO_THREAD_LOCAL -DSTBI_NO_THREAD_LOCALS
+INCLUDES := -I. -Isource -Ithirdparty -Ithirdparty/zlib -Ithirdparty/raknet -Ithirdparty/rapidjson -Ithirdparty/stb_image/include
+
+C_SRCS := $(wildcard thirdparty/zlib/*.c) thirdparty/stb_image/src/stb_image_impl.c thirdparty/stb_image/include/stb_vorbis.c
+CXX_SRCS := $(shell find source \
+    -path source/renderer/platform -prune -o \
+    -path source/renderer/hal/ogl -prune -o \
+    -path source/renderer/hal/d3d11 -prune -o \
+    -path source/renderer/hal/d3d9 -prune -o \
+    -path source/renderer/hal/dxgi -prune -o \
+    -path source/renderer/hal/null -prune -o \
+    -name '*.cpp' -print) \
+    source/renderer/hal/null/AlphaStateNull.cpp \
+    source/renderer/hal/null/RenderStateNull.cpp \
+    source/renderer/hal/null/FogStateNull.cpp \
+    $(wildcard thirdparty/raknet/*.cpp)
+
+# Makefile only supports SDL1 or SDL2 for now, and desktop only
+PLATFORM := sdl2
+GFX_API := OGL
+ifeq ($(PLATFORM),sdl2)
+DEFINES += -DUSE_SDL -DUSE_SDL2
+else
+DEFINES += -DUSE_SDL -DUSE_SDL1
+endif
+CXX_SRCS += platforms/sdl/$(PLATFORM)/main.cpp $(wildcard platforms/sdl/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/desktop/*.cpp)
+ifeq ($(GFX_API),OGL)
+DEFINES += -DMCE_GFX_API_OGL=1
+CXX_SRCS += $(wildcard renderer/hal/ogl/*.cpp) $(wildcard renderer/platform/ogl/*.cpp)
+else
+ifeq ($(GFX_API),OGL_SHADERS)
+DEFINES += -DMCE_GFX_API_OGL=1 -DFEATURE_GFX_SHADERS
+CXX_SRCS += $(wildcard renderer/hal/ogl/*.cpp) $(wildcard renderer/platform/ogl/*.cpp)
+else
+ifeq ($(GFX_API),NULL)
+DEFINES += -DMCE_GFX_API_NULL=1
+# why does the null hal have to have some sources included by default its so dumb
+CXX_SRCS += \
+    renderer/hal/null/BlendStateNull.cpp \
+    renderer/hal/null/BufferNull.cpp \
+    renderer/hal/null/ConstantBufferContainerNull.cpp \
+    renderer/hal/null/DepthStencilStateNull.cpp \
+    renderer/hal/null/ImmediateBufferNull.cpp \
+    renderer/hal/null/RasterizerStateNull.cpp \
+    renderer/hal/null/RenderContextNull.cpp \
+    renderer/hal/null/RenderDeviceNull.cpp \
+    renderer/hal/null/ShaderConstantNull.cpp \
+    renderer/hal/null/ShaderConstantWithDataNull.cpp \
+    renderer/hal/null/ShaderNull.cpp \
+    renderer/hal/null/ShaderProgramNull.cpp \
+    renderer/hal/null/TextureNull.cpp
+endif
+endif
+endif
+
+AUDIO_LIBRARY := openal
+INCLUDES += -Iplatforms/audio/$(AUDIO_LIBRARY)
+CXX_SRCS += $(wildcard platforms/audio/$(AUDIO_LIBRARY)/*.cpp)
+
+OBJS := $(addprefix build/,$(C_SRCS:.c=.c.o)) $(addprefix build/,$(CXX_SRCS:.cpp=.cpp.o))
+
+all: build/nbcraft build/assets
+
+build:
+	mkdir build
+
+build/assets: build
+	cp -r game/assets build
+	rm -rf build/assets/app
+
+build/nbcraft: $(OBJS) build
+	$(CXX) $(LDFLAGS) $(OBJS) -o build/nbcraft
+
+build/%.cpp.o: %.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(DEFINES) $(INCLUDES) $(CXXFLAGS) -c $< -o $@
+
+build/%.c.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(DEFINES) $(INCLUDES) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -36,29 +36,29 @@ endif
 CXX_SRCS += platforms/sdl/$(PLATFORM)/main.cpp $(wildcard platforms/sdl/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/desktop/*.cpp)
 ifeq ($(GFX_API),OGL)
 DEFINES += -DMCE_GFX_API_OGL=1
-CXX_SRCS += $(wildcard renderer/hal/ogl/*.cpp) $(wildcard renderer/platform/ogl/*.cpp)
+CXX_SRCS += $(shell find source/renderer/hal/ogl -name '*.cpp') $(wildcard source/renderer/platform/ogl/*.cpp)
 else
 ifeq ($(GFX_API),OGL_SHADERS)
 DEFINES += -DMCE_GFX_API_OGL=1 -DFEATURE_GFX_SHADERS
-CXX_SRCS += $(wildcard renderer/hal/ogl/*.cpp) $(wildcard renderer/platform/ogl/*.cpp)
+CXX_SRCS += $(shell find source/renderer/hal/ogl -name '*.cpp') $(wildcard source/renderer/platform/ogl/*.cpp)
 else
 ifeq ($(GFX_API),NULL)
 DEFINES += -DMCE_GFX_API_NULL=1
 # why does the null hal have to have some sources included by default its so dumb
 CXX_SRCS += \
-    renderer/hal/null/BlendStateNull.cpp \
-    renderer/hal/null/BufferNull.cpp \
-    renderer/hal/null/ConstantBufferContainerNull.cpp \
-    renderer/hal/null/DepthStencilStateNull.cpp \
-    renderer/hal/null/ImmediateBufferNull.cpp \
-    renderer/hal/null/RasterizerStateNull.cpp \
-    renderer/hal/null/RenderContextNull.cpp \
-    renderer/hal/null/RenderDeviceNull.cpp \
-    renderer/hal/null/ShaderConstantNull.cpp \
-    renderer/hal/null/ShaderConstantWithDataNull.cpp \
-    renderer/hal/null/ShaderNull.cpp \
-    renderer/hal/null/ShaderProgramNull.cpp \
-    renderer/hal/null/TextureNull.cpp
+    source/renderer/hal/null/BlendStateNull.cpp \
+    source/renderer/hal/null/BufferNull.cpp \
+    source/renderer/hal/null/ConstantBufferContainerNull.cpp \
+    source/renderer/hal/null/DepthStencilStateNull.cpp \
+    source/renderer/hal/null/ImmediateBufferNull.cpp \
+    source/renderer/hal/null/RasterizerStateNull.cpp \
+    source/renderer/hal/null/RenderContextNull.cpp \
+    source/renderer/hal/null/RenderDeviceNull.cpp \
+    source/renderer/hal/null/ShaderConstantNull.cpp \
+    source/renderer/hal/null/ShaderConstantWithDataNull.cpp \
+    source/renderer/hal/null/ShaderNull.cpp \
+    source/renderer/hal/null/ShaderProgramNull.cpp \
+    source/renderer/hal/null/TextureNull.cpp
 endif
 endif
 endif
@@ -79,7 +79,8 @@ build/assets: build
 	rm -rf build/assets/app
 
 build/nbcraft: $(OBJS) build
-	$(CXX) $(LDFLAGS) $(OBJS) -o build/nbcraft
+	$(AR) rcs build/nbcraft.a $(OBJS)
+	$(CXX) $(LDFLAGS) build/nbcraft.a -o build/nbcraft
 
 build/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -30,17 +30,21 @@ PLATFORM := sdl2
 GFX_API := OGL
 ifeq ($(PLATFORM),sdl2)
 DEFINES += -DUSE_SDL -DUSE_SDL2
+LIBS += -lSDL2
 else
 DEFINES += -DUSE_SDL -DUSE_SDL1
+LIBS += -lSDL
 endif
 CXX_SRCS += platforms/sdl/$(PLATFORM)/main.cpp $(wildcard platforms/sdl/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/desktop/*.cpp)
 ifeq ($(GFX_API),OGL)
 DEFINES += -DMCE_GFX_API_OGL=1
 CXX_SRCS += $(shell find source/renderer/hal/ogl -name '*.cpp') $(wildcard source/renderer/platform/ogl/*.cpp)
+LIBS += -lGL
 else
 ifeq ($(GFX_API),OGL_SHADERS)
 DEFINES += -DMCE_GFX_API_OGL=1 -DFEATURE_GFX_SHADERS
 CXX_SRCS += $(shell find source/renderer/hal/ogl -name '*.cpp') $(wildcard source/renderer/platform/ogl/*.cpp)
+LIBS += -lGL
 else
 ifeq ($(GFX_API),NULL)
 DEFINES += -DMCE_GFX_API_NULL=1
@@ -66,6 +70,9 @@ endif
 AUDIO_LIBRARY := openal
 INCLUDES += -Iplatforms/audio/$(AUDIO_LIBRARY)
 CXX_SRCS += $(wildcard platforms/audio/$(AUDIO_LIBRARY)/*.cpp)
+ifeq ($(AUDIO_LIBRARY),openal)
+LIBS += -lopenal
+endif
 
 OBJS := $(addprefix build/,$(C_SRCS:.c=.c.o)) $(addprefix build/,$(CXX_SRCS:.cpp=.cpp.o))
 
@@ -80,7 +87,7 @@ build/assets: build
 
 build/nbcraft: $(OBJS) build
 	$(AR) rcs build/nbcraft.a $(OBJS)
-	$(CXX) $(LDFLAGS) build/nbcraft.a -o build/nbcraft
+	$(CXX) $(LDFLAGS) build/nbcraft.a $(LIBS) -o build/nbcraft
 
 build/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ This project uses CMake on Unix-like systems.
 - `cmake` (CMake)
 - `libsdl2-dev` (SDL2)
 - `libopenal-dev` (OpenAL)
-- `zlib1g-dev` (ZLib)
 
 #### Dependencies (Haiku)
 
@@ -219,6 +218,18 @@ mkdir build && cd build
 cmake ..
 cmake --build .
 # Run
+./nbcraft
+```
+
+#### Makefile
+
+For systems where cmake is not available, there is a GNU Makefile available. The dependencies are the same except without CMake.
+You should ***ALWAYS*** try to use CMake if you can, the Makefile is very limited and only intended for old or obscure systems that cannot run CMake.
+
+```sh
+make
+# Run
+cd build
 ./nbcraft
 ```
 

--- a/thirdparty/raknet/LocklessTypes.cpp
+++ b/thirdparty/raknet/LocklessTypes.cpp
@@ -24,7 +24,7 @@ uint32_t LocklessUint32_t::Increment(void)
 {
 #if defined(_WIN32) && !defined(LOCKLESS_TYPES_USE_MUTEX)
 	return (uint32_t) InterlockedIncrement(&value);
-#elif defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX)
+#elif defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX) || !defined(__GNUC__) || __GNUC__ < 4
 	uint32_t v;
 	mutex.Lock();
 	++value;
@@ -39,7 +39,7 @@ uint32_t LocklessUint32_t::Decrement(void)
 {
 #if defined(_WIN32) && !defined(LOCKLESS_TYPES_USE_MUTEX)
 	return (uint32_t) InterlockedDecrement(&value);
-#elif defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX)
+#elif defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX) || !defined(__GNUC__) || __GNUC__ < 4
 	uint32_t v;
 	mutex.Lock();
 	--value;

--- a/thirdparty/raknet/LocklessTypes.h
+++ b/thirdparty/raknet/LocklessTypes.h
@@ -14,7 +14,7 @@
 #include "Export.h"
 #include "NativeTypes.h"
 #include "WindowsIncludes.h"
-#if defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX)
+#if defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX) || !defined(__GNUC__) || __GNUC__ < 4
 // __sync_fetch_and_add not supported apparently
 #include "SimpleMutex.h"
 #endif
@@ -36,7 +36,7 @@ public:
 protected:
 #if defined(_WIN32) && !defined(LOCKLESS_TYPES_USE_MUTEX)
 	volatile LONG value;
-#elif defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX)
+#elif defined(ANDROID) || defined(__S3E__) || defined(__APPLE__) || defined(LOCKLESS_TYPES_USE_MUTEX) || !defined(__GNUC__) || __GNUC__ < 4
 	// __sync_fetch_and_add not supported apparently
 	SimpleMutex mutex;
 	uint32_t value;


### PR DESCRIPTION
I've been trying to run NBCraft on weird old unix systems lately and the biggest obstacle has been CMake, which requires a modern C++ compiler/libraries as well as libuv (a library that does not care about portability at all).  A GNU makefile makes it ***much*** easier to get running on old systems, especially since our rigid adherence to C++98 has made it possible to build with very old compilers.
I've tested the build on Debian 4.0 with GCC 3.4 and it works, GCC 3.3 and below do not work.