### PR TITLE
Use the BufferId typedef in SoundStream

### DIFF
--- a/platforms/audio/directsound/SoundStreamDS.cpp
+++ b/platforms/audio/directsound/SoundStreamDS.cpp
@@ -252,7 +252,7 @@ void SoundStreamDS::_update()
     }
 }
 
-void SoundStreamDS::_publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer)
+void SoundStreamDS::_publishBuffer(BufferId destBufferId, const SoundBuffer& sourceBuffer)
 {
     if (destBufferId >= m_buffers.size() || !m_source) return;
 

--- a/platforms/audio/directsound/SoundStreamDS.hpp
+++ b/platforms/audio/directsound/SoundStreamDS.hpp
@@ -29,7 +29,7 @@ protected:
     bool _open(const std::string& fileName) override;
     void _close() override;
     void _update() override;
-    void _publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer) override;
+    void _publishBuffer(BufferId destBufferId, const SoundBuffer& sourceBuffer) override;
 
 private:
     void _deleteSource();

--- a/platforms/audio/openal/SoundStreamOAL.cpp
+++ b/platforms/audio/openal/SoundStreamOAL.cpp
@@ -46,7 +46,7 @@ void SoundStreamOAL::_resetSource()
 
 void SoundStreamOAL::_deleteBuffers()
 {
-    alDeleteBuffers(m_buffers.size(), _getBuffersArray());
+    alDeleteBuffers(static_cast<ALsizei>(m_buffers.size()), _getBuffersArray());
     AL_ERROR_CHECK();
 
     m_buffers.clear();
@@ -167,7 +167,7 @@ void SoundStreamOAL::_update()
     }
 }
 
-void SoundStreamOAL::_publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer)
+void SoundStreamOAL::_publishBuffer(BufferId destBufferId, const SoundBuffer& sourceBuffer)
 {
     alBufferData(m_buffers[destBufferId], m_alFormat, sourceBuffer.m_pData, sourceBuffer.m_dataSize * sizeof(int16_t), m_info.sample_rate);
     AL_ERROR_CHECK();

--- a/platforms/audio/openal/SoundStreamOAL.hpp
+++ b/platforms/audio/openal/SoundStreamOAL.hpp
@@ -13,7 +13,7 @@
 class SoundStreamOAL : public SoundStream
 {
 private:
-    typedef std::map<ALuint, unsigned int> BufferIdMap;
+    typedef std::map<ALuint, BufferId> BufferIdMap;
 
 public:
     SoundStreamOAL();
@@ -37,7 +37,7 @@ protected:
     bool _open(const std::string& fileName) override;
     void _close() override;
     void _update() override;
-    void _publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer) override;
+    void _publishBuffer(BufferId destBufferId, const SoundBuffer& sourceBuffer) override;
 
 private:
     std::vector<ALuint> m_buffers;

--- a/platforms/audio/openal/SoundSystemOAL.cpp
+++ b/platforms/audio/openal/SoundSystemOAL.cpp
@@ -410,7 +410,7 @@ void SoundSystemOAL::startEngine()
 	{
 		m_musicStream = new SoundStreamOAL();
 	}
-	catch (const std::runtime_error& e)
+	catch (const std::runtime_error&)
 	{
 		LOG_E("Failed to init audio");
 		return;

--- a/platforms/audio/xaudio2/SoundStreamXA2.cpp
+++ b/platforms/audio/xaudio2/SoundStreamXA2.cpp
@@ -161,7 +161,7 @@ void SoundStreamXA2::_update()
     }
 }
 
-void SoundStreamXA2::_publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer)
+void SoundStreamXA2::_publishBuffer(BufferId destBufferId, const SoundBuffer& sourceBuffer)
 {
     if (!m_sourceVoice) return;
 

--- a/platforms/audio/xaudio2/SoundStreamXA2.hpp
+++ b/platforms/audio/xaudio2/SoundStreamXA2.hpp
@@ -29,7 +29,7 @@ protected:
     bool _open(const std::string& fileName);
     void _close();
     void _update();
-    void _publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer);
+    void _publishBuffer(BufferId destBufferId, const SoundBuffer& sourceBuffer);
 
 private:
     void _createVoice();

--- a/source/client/sound/SoundStream.cpp
+++ b/source/client/sound/SoundStream.cpp
@@ -30,7 +30,7 @@ void SoundStream::_deleteDecoder()
     m_decoder = nullptr;
 }
 
-bool SoundStream::_stream(int bufferId)
+bool SoundStream::_stream(BufferId bufferId)
 {
     int size = 0;
     int result = 0;

--- a/source/client/sound/SoundStream.hpp
+++ b/source/client/sound/SoundStream.hpp
@@ -27,9 +27,9 @@ protected:
     virtual bool _open(const std::string& fileName) = 0;
     virtual void _close() = 0;
     virtual void _update() = 0;
-    virtual void _publishBuffer(unsigned int destBufferId, const SoundBuffer& sourceBuffer) = 0;
+    virtual void _publishBuffer(BufferId destBufferId, const SoundBuffer& sourceBuffer) = 0;
 
-    bool _stream(int bufferId);
+    bool _stream(BufferId bufferId);
 
 public:
     float getVolume() const { return m_volume; }


### PR DESCRIPTION
BufferId is defined in the header of SoundStream, but isn't used anywhere.
This also fixes warnings caused by using the wrong types.