### PR TITLE
Fix renderer warnings

### DIFF
--- a/source/renderer/ConstantBufferMetaData.cpp
+++ b/source/renderer/ConstantBufferMetaData.cpp
@@ -41,13 +41,13 @@ const UniformMetaData* ConstantBufferMetaData::getUniformMetaData(const std::str
     return nullptr;
 }
 
-unsigned int ConstantBufferMetaData::getRequiredSpaceForUniforms() const
+size_t ConstantBufferMetaData::getRequiredSpaceForUniforms() const
 {
     if (m_uniformMetaData.empty())
         return 0;
     
     const UniformMetaData& lastUniform = m_uniformMetaData.back();
-    unsigned int unalignedSize = lastUniform.getSize() + lastUniform.m_byteOffset;
+    size_t unalignedSize = lastUniform.getSize() + lastUniform.m_byteOffset;
 
     return AlignmentHelper::getAlignedOffset(unalignedSize, 16);
 }

--- a/source/renderer/ConstantBufferMetaData.hpp
+++ b/source/renderer/ConstantBufferMetaData.hpp
@@ -21,6 +21,6 @@ namespace mce
 
         const std::string& getConstantBufferName() const;
         const UniformMetaData* getUniformMetaData(const std::string& uniformName) const;
-        unsigned int getRequiredSpaceForUniforms() const;
+        size_t getRequiredSpaceForUniforms() const;
     };
 }

--- a/source/renderer/ConstantBufferMetaDataManager.cpp
+++ b/source/renderer/ConstantBufferMetaDataManager.cpp
@@ -21,8 +21,8 @@ void ConstantBufferMetaDataManager::allocateConstantBufferContainers()
         ConstantBufferMetaData& bufferMeta = m_constantBufferMetaDataList[i];
         ConstantBufferContainer buffer;
 
-        unsigned int uniformCount = bufferMeta.m_uniformMetaData.size();
-        unsigned int bufferSize = bufferMeta.getRequiredSpaceForUniforms();
+        size_t uniformCount = bufferMeta.m_uniformMetaData.size();
+        size_t bufferSize = bufferMeta.getRequiredSpaceForUniforms();
         buffer.reserveMemoryForShaderConstants(uniformCount, bufferSize);
 
         buffer.m_constantBufferName = bufferMeta.getConstantBufferName();

--- a/source/renderer/UniformMetaData.cpp
+++ b/source/renderer/UniformMetaData.cpp
@@ -11,7 +11,7 @@ UniformMetaData::UniformMetaData()
     m_constantBufferMetaDataParent = nullptr;
 }
 
-unsigned int UniformMetaData::getSize() const
+size_t UniformMetaData::getSize() const
 {
     return ShaderPrimitiveTypeHelper::sizeInBytesFromShaderPrimitiveType(m_shaderPrimitiveType);
 }

--- a/source/renderer/UniformMetaData.hpp
+++ b/source/renderer/UniformMetaData.hpp
@@ -10,8 +10,8 @@ namespace mce
     class UniformMetaData
     {
     public:
-        unsigned int m_numberOfElements;
-        unsigned int m_byteOffset;
+        size_t m_numberOfElements;
+        size_t m_byteOffset;
         ShaderPrimitiveTypes m_shaderPrimitiveType;
         ConstantBufferMetaData* m_constantBufferMetaDataParent;
         std::string m_uniformName;
@@ -19,6 +19,6 @@ namespace mce
     public:
         UniformMetaData();
 
-        unsigned int getSize() const;
+        size_t getSize() const;
     };
 }

--- a/source/renderer/hal/base/ConstantBufferContainerBase.cpp
+++ b/source/renderer/hal/base/ConstantBufferContainerBase.cpp
@@ -49,7 +49,7 @@ void ConstantBufferContainerBase::_move(ConstantBufferContainerBase& other)
     other.m_bWriteEnabled = temp;
 }
 
-void ConstantBufferContainerBase::reserveMemoryForShaderConstants(unsigned int shaderConstSize, unsigned int constBufferSize)
+void ConstantBufferContainerBase::reserveMemoryForShaderConstants(size_t shaderConstSize, size_t constBufferSize)
 {
     m_shaderConstants->reserve(shaderConstSize);
     m_constantBufferBytes->resize(constBufferSize);

--- a/source/renderer/hal/base/ConstantBufferContainerBase.hpp
+++ b/source/renderer/hal/base/ConstantBufferContainerBase.hpp
@@ -31,11 +31,11 @@ namespace mce
         void _move(ConstantBufferContainerBase& other);
 
     public:
-        void bindConstantBuffer(RenderContext& context, unsigned int, unsigned int) { }
+        void bindConstantBuffer(RenderContext& context, size_t, size_t) { }
 
         void sync(RenderContext& context) { }
         void allocateRenderContextBuffer(RenderContext& context) { }
-        void reserveMemoryForShaderConstants(unsigned int shaderConstSize, unsigned int constBufferSize);
+        void reserveMemoryForShaderConstants(size_t shaderConstSize, size_t constBufferSize);
         void registerReflectedShaderParameter(const UniformMetaData& uniMeta);
         void registerShaderParameter(const ShaderConstantBase &shaderConst);
         void finalizeConstantBufferLayout();

--- a/source/renderer/hal/base/ShaderConstantBase.hpp
+++ b/source/renderer/hal/base/ShaderConstantBase.hpp
@@ -11,8 +11,8 @@ namespace mce
     {
     public:
         std::string m_name;
-        unsigned int m_numberOfElements;
-        unsigned int m_byteOffset;
+        size_t m_numberOfElements;
+        size_t m_byteOffset;
         ShaderPrimitiveTypes m_shaderPrimitiveType;
         bool m_dirty;
 
@@ -26,7 +26,7 @@ namespace mce
 
         void release();
         const std::string& getName() const { return m_name; }
-        unsigned int getSize() const { return ShaderPrimitiveTypeHelper::sizeInBytesFromShaderPrimitiveType(m_shaderPrimitiveType); }
+        size_t getSize() const { return ShaderPrimitiveTypeHelper::sizeInBytesFromShaderPrimitiveType(m_shaderPrimitiveType); }
         ShaderPrimitiveTypes getType() const { return m_shaderPrimitiveType; }
         bool isDirty() const { return m_dirty; }
 

--- a/source/renderer/hal/enums/RenderStateType_JsonParser.cpp
+++ b/source/renderer/hal/enums/RenderStateType_JsonParser.cpp
@@ -3,6 +3,22 @@
 
 namespace mce
 {
+    static std::map<std::string, RenderStateType> _CreateRenderStateTypeMap()
+    {
+        std::map<std::string, RenderStateType> m;
+        m["DisableDepthTest"] = RS_DISABLE_DEPTH_TEST;
+        m["Blending"] = RS_BLENDING;
+        m["PolygonOffset"] = RS_POLYGON_OFFSET;
+        m["DisableCulling"] = RS_DISABLE_CULLING;
+        m["DisableColorWrite"] = RS_DISABLE_COLOR_WRITE;
+        m["DisableDepthWrite"] = RS_DISABLE_DEPTH_WRITE;
+        m["StencilWrite"] = RS_STENCIL_WRITE;
+        m["InvertCulling"] = RS_INVERT_CULLING;
+        m["EnableStencilTest"] = RS_ENABLE_STENCIL_TEST;
+        m["EnableAlphaTest"] = RS_ENABLE_ALPHA_TEST;
+        m["Textured"] = RS_ENABLE_TEXTURE;
+        return m;
+    }
 
 	template <>
 	bool parse<RenderStateType>(const rapidjson::Value& root, const std::string& name, RenderStateType& out)
@@ -10,4 +26,5 @@ namespace mce
 		return parse<RenderStateType>(root, name, _renderStateTypeMap, out);
 	}
 
+    const std::map<std::string, RenderStateType> _renderStateTypeMap = _CreateRenderStateTypeMap();
 }

--- a/source/renderer/hal/enums/RenderStateType_JsonParser.hpp
+++ b/source/renderer/hal/enums/RenderStateType_JsonParser.hpp
@@ -6,21 +6,5 @@
 
 namespace mce
 {
-    std::map<std::string, RenderStateType> _CreateRenderStateTypeMap()
-    {
-        std::map<std::string, RenderStateType> m;
-        m["DisableDepthTest"] = RS_DISABLE_DEPTH_TEST;
-        m["Blending"] = RS_BLENDING;
-        m["PolygonOffset"] = RS_POLYGON_OFFSET;
-        m["DisableCulling"] = RS_DISABLE_CULLING;
-        m["DisableColorWrite"] = RS_DISABLE_COLOR_WRITE;
-        m["DisableDepthWrite"] = RS_DISABLE_DEPTH_WRITE;
-        m["StencilWrite"] = RS_STENCIL_WRITE;
-        m["InvertCulling"] = RS_INVERT_CULLING;
-        m["EnableStencilTest"] = RS_ENABLE_STENCIL_TEST;
-        m["EnableAlphaTest"] = RS_ENABLE_ALPHA_TEST;
-        m["Textured"] = RS_ENABLE_TEXTURE;
-        return m;
-    }
-    const std::map<std::string, RenderStateType> _renderStateTypeMap = _CreateRenderStateTypeMap();
+    extern const std::map<std::string, RenderStateType> _renderStateTypeMap;
 }

--- a/source/renderer/hal/enums/ShaderPrimitiveTypes.cpp
+++ b/source/renderer/hal/enums/ShaderPrimitiveTypes.cpp
@@ -4,7 +4,7 @@
 
 using namespace mce;
 
-int ShaderPrimitiveTypeHelper::sizeInBytesFromShaderPrimitiveType(ShaderPrimitiveTypes shaderPrimitiveType)
+size_t ShaderPrimitiveTypeHelper::sizeInBytesFromShaderPrimitiveType(ShaderPrimitiveTypes shaderPrimitiveType)
 {
     switch (shaderPrimitiveType)
     {

--- a/source/renderer/hal/enums/ShaderPrimitiveTypes.hpp
+++ b/source/renderer/hal/enums/ShaderPrimitiveTypes.hpp
@@ -29,7 +29,7 @@ namespace mce
 	class ShaderPrimitiveTypeHelper
 	{
 	public:
-		static int sizeInBytesFromShaderPrimitiveType(ShaderPrimitiveTypes shaderPrimitiveType);
+		static size_t sizeInBytesFromShaderPrimitiveType(ShaderPrimitiveTypes shaderPrimitiveType);
 	};
 
 	MC_UNUSED static const char* ShaderPrimitiveTypeToString[] = {

--- a/source/renderer/hal/enums/ShaderPrimitiveTypes.hpp
+++ b/source/renderer/hal/enums/ShaderPrimitiveTypes.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "compat/Unused.hpp"
+#include <cstddef>
 
 namespace mce
 {


### PR DESCRIPTION
- Fixed the renderer using `unsigned int` instead of `size_t`. Even though they're both technically the same, MSVC does not like mismatching typedefs and their actual types.
- Fixed `_renderStateTypeMap` being defined twice