### PR TITLE
Add scroll wheel support to SDL 1.2 + Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,13 @@ GFX_API := OGL
 ifeq ($(PLATFORM),sdl2)
 HEADERS += $(wildcard thirdparty/SDL/*.h)
 DEFINES += -DUSE_SDL -DUSE_SDL2
-LIBS += -lSDL2
+SDL2_LIBS := $(shell pkg-config --libs sdl2)
+LIBS += $(SDL2_LIBS)
 else
 HEADERS += $(wildcard thirdparty/SDL/*.h)
 DEFINES += -DUSE_SDL -DUSE_SDL1
-LIBS += -lSDL
-ifeq ($(OS),Darwin)
-LIBS += -framework AppKit
-PRELIBS := -lSDLmain
-endif
+SDL1_LIBS := $(shell pkg-config --libs sdl)
+LIBS += $(SDL1_LIBS)
 endif
 CXX_SRCS += platforms/sdl/$(PLATFORM)/main.cpp $(wildcard platforms/sdl/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/base/*.cpp) $(wildcard platforms/sdl/$(PLATFORM)/desktop/*.cpp)
 ifeq ($(GFX_API),OGL)

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,8 @@ endif
 
 all: build/nbcraft
 
+-include $(OBJS:.o=.d)
+
 build/nbcraft: $(OBJS)
 	ln -sf ../game/assets build
 	$(AR) rcs build/nbcraft.a $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ all: build/nbcraft
 build/nbcraft: $(OBJS)
 	ln -sf ../game/assets build
 	$(AR) rcs build/nbcraft.a $(OBJS)
-	$(CXX) $(LDFLAGS) $(PRELIBS) build/nbcraft.a $(LIBS) -o $@
+	$(CXX) $(LDFLAGS) build/nbcraft.a $(LIBS) -o $@
 
 build/%.cpp.o: %.cpp $(HEADERS)
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,10 @@ endif
 
 OBJS := $(addprefix build/,$(C_SRCS:.c=.c.o)) $(addprefix build/,$(CXX_SRCS:.cpp=.cpp.o))
 
+ifndef DISABLE_MMD
+DEPFLAGS = -MMD -MP
+endif
+
 all: build/nbcraft
 
 build/nbcraft: $(OBJS)
@@ -132,13 +136,13 @@ build/nbcraft: $(OBJS)
 	$(AR) rcs build/nbcraft.a $(OBJS)
 	$(CXX) $(LDFLAGS) build/nbcraft.a $(LIBS) -o $@
 
-build/%.cpp.o: %.cpp $(HEADERS)
+build/%.cpp.o: %.cpp $(if $(DISABLE_MMD),$(HEADERS))
 	@mkdir -p $(dir $@)
-	$(CXX) $(DEFINES) $(INCLUDES) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(DEFINES) $(INCLUDES) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
-build/%.c.o: %.c $(HEADERS)
+build/%.c.o: %.c $(if $(DISABLE_MMD),$(HEADERS))
 	@mkdir -p $(dir $@)
-	$(CC) $(DEFINES) $(INCLUDES) $(CFLAGS) -c $< -o $@
+	$(CC) $(DEFINES) $(INCLUDES) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 clean:
 	rm -rf build

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -152,6 +152,7 @@ static void handle_events()
         {
             case SDL_KEYDOWN:
             case SDL_KEYUP:
+            {
                 if (event.type == SDL_KEYDOWN && event.key.keysym.unicode > 0)
                 {
                     if ((event.key.keysym.unicode & 0xFF80) == 0)
@@ -167,8 +168,10 @@ static void handle_events()
 
                 g_pAppPlatform->handleKeyEvent(event);
                 break;
+            }
             case SDL_JOYBUTTONDOWN:
             case SDL_JOYBUTTONUP:
+            {
                 // Hate this hack
                 if (event.jbutton.button == SDL_CONTROLLER_BUTTON_START && event.jbutton.state == SDL_PRESSED)
                 {
@@ -176,6 +179,7 @@ static void handle_events()
                 }
                 g_pAppPlatform->handleControllerButtonEvent(event.jbutton.which, event.jbutton.button, event.jbutton.state);
                 break;
+            }
             case SDL_MOUSEBUTTONDOWN:
             case SDL_MOUSEBUTTONUP:
                 if (event.button.button == SDL_BUTTON_WHEELUP)
@@ -204,13 +208,17 @@ static void handle_events()
                 g_pAppPlatform->handleControllerAxisEvent(event.jaxis.which, event.jaxis.axis, event.jaxis.value);
                 break;
             case SDL_VIDEORESIZE:
+            {
                 screen = SDL_SetVideoMode(event.resize.w, event.resize.h, 0, VIDEO_FLAGS);
                 g_pApp->onGraphicsReset();
                 window_resized = true;
                 break;
+            }
             case SDL_QUIT:
+            {
                 g_pApp->quit();
                 break;
+            }
         }
     }
 }

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -170,20 +170,27 @@ static void handle_events()
                 break;
             }
             case SDL_MOUSEBUTTONDOWN:
-            case SDL_MOUSEBUTTONUP:
                 if (event.button.button == SDL_BUTTON_WHEELUP)
+                {
                     Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, Mouse::getX(), Mouse::getY());
-                else if (event.button.button == SDL_BUTTON_WHEELDOWN)
-                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, true, Mouse::getX(), Mouse::getY());
-                else {
-                    const float scale = g_fPointToPixelScale;
-                    MouseButtonType type = UsedAppPlatform::GetMouseButtonType(event.button.button);
-                    bool state = UsedAppPlatform::GetMouseButtonState(event);
-                    float x = event.button.x * scale;
-                    float y = event.button.y * scale;
-                    Mouse::feed(type, state, x, y);
+                    break;
                 }
+                else if (event.button.button == SDL_BUTTON_WHEELDOWN)
+                {
+                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, true, Mouse::getX(), Mouse::getY());
+                    break;
+                }
+                // fall through
+            case SDL_MOUSEBUTTONUP:
+            {
+                const float scale = g_fPointToPixelScale;
+                MouseButtonType type = UsedAppPlatform::GetMouseButtonType(event.button.button);
+                bool state = UsedAppPlatform::GetMouseButtonState(event);
+                float x = event.button.x * scale;
+                float y = event.button.y * scale;
+                Mouse::feed(type, state, x, y);
                 break;
+            }
             case SDL_MOUSEMOTION:
             {
                 float scale = g_fPointToPixelScale;

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -186,8 +186,8 @@ static void handle_events()
                     Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, true, x, y);
                     break;
                 }
-                // fall through
             }
+            // fall through
             case SDL_MOUSEBUTTONUP:
             {
                 const float scale = g_fPointToPixelScale;

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -170,10 +170,9 @@ static void handle_events()
                 break;
             }
             case SDL_MOUSEBUTTONDOWN:
-            {
-                const float scale = g_fPointToPixelScale;
                 if (event.button.button == SDL_BUTTON_WHEELUP)
                 {
+                    const float scale = g_fPointToPixelScale;
                     float x = event.button.x * scale;
                     float y = event.button.y * scale;
                     Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, x, y);
@@ -181,13 +180,13 @@ static void handle_events()
                 }
                 else if (event.button.button == SDL_BUTTON_WHEELDOWN)
                 {
+                    const float scale = g_fPointToPixelScale;
                     float x = event.button.x * scale;
                     float y = event.button.y * scale;
                     Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, true, x, y);
                     break;
                 }
-            }
-            // fall through
+                // fall through
             case SDL_MOUSEBUTTONUP:
             {
                 const float scale = g_fPointToPixelScale;

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -130,6 +130,17 @@ static void teardown()
     }
 }
 
+// These macros aren't present in older versions of SDL 1.2.
+// In those versions, event.button.button will either never
+// equal these, or it will and scrolling works the same way,
+// so it's safe to define them ourselves.
+#ifndef SDL_BUTTON_WHEELUP
+#define SDL_BUTTON_WHEELUP 4
+#endif
+#ifndef SDL_BUTTON_WHEELDOWN
+#define SDL_BUTTON_WHEELDOWN 5
+#endif
+
 // Handle Events
 static bool window_resized = false;
 static void handle_events()
@@ -141,7 +152,6 @@ static void handle_events()
         {
             case SDL_KEYDOWN:
             case SDL_KEYUP:
-            {
                 if (event.type == SDL_KEYDOWN && event.key.keysym.unicode > 0)
                 {
                     if ((event.key.keysym.unicode & 0xFF80) == 0)
@@ -157,10 +167,8 @@ static void handle_events()
 
                 g_pAppPlatform->handleKeyEvent(event);
                 break;
-            }
             case SDL_JOYBUTTONDOWN:
             case SDL_JOYBUTTONUP:
-            {
                 // Hate this hack
                 if (event.jbutton.button == SDL_CONTROLLER_BUTTON_START && event.jbutton.state == SDL_PRESSED)
                 {
@@ -168,18 +176,21 @@ static void handle_events()
                 }
                 g_pAppPlatform->handleControllerButtonEvent(event.jbutton.which, event.jbutton.button, event.jbutton.state);
                 break;
-            }
             case SDL_MOUSEBUTTONDOWN:
             case SDL_MOUSEBUTTONUP:
-            {
-                const float scale = g_fPointToPixelScale;
-                MouseButtonType type = UsedAppPlatform::GetMouseButtonType(event.button.button);
-                bool state = UsedAppPlatform::GetMouseButtonState(event);
-                float x = event.button.x * scale;
-                float y = event.button.y * scale;
-                Mouse::feed(type, state, x, y);
+                if (event.button.button == SDL_BUTTON_WHEELUP)
+                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, Mouse::getX(), Mouse::getY());
+                else if (event.button.button == SDL_BUTTON_WHEELDOWN)
+                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, Mouse::getX(), Mouse::getY());
+                else {
+                    const float scale = g_fPointToPixelScale;
+                    MouseButtonType type = UsedAppPlatform::GetMouseButtonType(event.button.button);
+                    bool state = UsedAppPlatform::GetMouseButtonState(event);
+                    float x = event.button.x * scale;
+                    float y = event.button.y * scale;
+                    Mouse::feed(type, state, x, y);
+                }
                 break;
-            }
             case SDL_MOUSEMOTION:
             {
                 float scale = g_fPointToPixelScale;
@@ -193,17 +204,13 @@ static void handle_events()
                 g_pAppPlatform->handleControllerAxisEvent(event.jaxis.which, event.jaxis.axis, event.jaxis.value);
                 break;
             case SDL_VIDEORESIZE:
-            {
                 screen = SDL_SetVideoMode(event.resize.w, event.resize.h, 0, VIDEO_FLAGS);
                 g_pApp->onGraphicsReset();
                 window_resized = true;
                 break;
-            }
             case SDL_QUIT:
-            {
                 g_pApp->quit();
                 break;
-            }
         }
     }
 }

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -130,17 +130,6 @@ static void teardown()
     }
 }
 
-// These macros aren't present in older versions of SDL 1.2.
-// In those versions, event.button.button will either never
-// equal these, or it will and scrolling works the same way,
-// so it's safe to define them ourselves.
-#ifndef SDL_BUTTON_WHEELUP
-#define SDL_BUTTON_WHEELUP 4
-#endif
-#ifndef SDL_BUTTON_WHEELDOWN
-#define SDL_BUTTON_WHEELDOWN 5
-#endif
-
 // Handle Events
 static bool window_resized = false;
 static void handle_events()

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -170,17 +170,24 @@ static void handle_events()
                 break;
             }
             case SDL_MOUSEBUTTONDOWN:
+            {
+                const float scale = g_fPointToPixelScale;
                 if (event.button.button == SDL_BUTTON_WHEELUP)
                 {
-                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, Mouse::getX(), Mouse::getY());
+                    float x = event.button.x * scale;
+                    float y = event.button.y * scale;
+                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, x, y);
                     break;
                 }
                 else if (event.button.button == SDL_BUTTON_WHEELDOWN)
                 {
-                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, true, Mouse::getX(), Mouse::getY());
+                    float x = event.button.x * scale;
+                    float y = event.button.y * scale;
+                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, true, x, y);
                     break;
                 }
                 // fall through
+            }
             case SDL_MOUSEBUTTONUP:
             {
                 const float scale = g_fPointToPixelScale;

--- a/platforms/sdl/sdl1/main.cpp
+++ b/platforms/sdl/sdl1/main.cpp
@@ -174,7 +174,7 @@ static void handle_events()
                 if (event.button.button == SDL_BUTTON_WHEELUP)
                     Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, Mouse::getX(), Mouse::getY());
                 else if (event.button.button == SDL_BUTTON_WHEELDOWN)
-                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, false, Mouse::getX(), Mouse::getY());
+                    Mouse::feed(MOUSE_BUTTON_SCROLLWHEEL, true, Mouse::getX(), Mouse::getY());
                 else {
                     const float scale = g_fPointToPixelScale;
                     MouseButtonType type = UsedAppPlatform::GetMouseButtonType(event.button.button);

--- a/thirdparty/SDL/SDL.h
+++ b/thirdparty/SDL/SDL.h
@@ -17,3 +17,15 @@
 #else
     #include <SDL2/SDL.h>
 #endif
+
+// These macros aren't present in older versions of SDL 1.2.
+// In those versions, event.button.button will either never
+// equal these, or it will and scrolling works the same way,
+// so it's safe to define them ourselves.
+#ifndef SDL_BUTTON_WHEELUP
+#define SDL_BUTTON_WHEELUP 4
+#endif
+#ifndef SDL_BUTTON_WHEELDOWN
+#define SDL_BUTTON_WHEELDOWN 5
+#endif
+

--- a/thirdparty/SDL/SDL.h
+++ b/thirdparty/SDL/SDL.h
@@ -18,8 +18,9 @@
     #ifdef USE_SDL1
         // These macros aren't present in older versions of SDL 1.2.
         // In those versions, event.button.button will either never
-        // equal these, or it will and scrolling works the same way,
-        // so it's safe to define them ourselves.
+        // equal these, having the effect of silently disabling scroll
+        // wheel support, or it will and scrolling will work the same
+        // way, so it's safe to define them ourselves.
         #ifndef SDL_BUTTON_WHEELUP
         #define SDL_BUTTON_WHEELUP 4
         #endif

--- a/thirdparty/SDL/SDL.h
+++ b/thirdparty/SDL/SDL.h
@@ -19,8 +19,8 @@
         // These macros aren't present in older versions of SDL 1.2.
         // In those versions, event.button.button will either never
         // equal these, having the effect of silently disabling scroll
-        // wheel support, or it will and scrolling will work the same
-        // way, so it's safe to define them ourselves.
+        // wheel support, or it will and scrolling will work normally,
+        // so it's safe to define them ourselves.
         #ifndef SDL_BUTTON_WHEELUP
         #define SDL_BUTTON_WHEELUP 4
         #endif

--- a/thirdparty/SDL/SDL.h
+++ b/thirdparty/SDL/SDL.h
@@ -14,18 +14,19 @@
     #else
         #include <SDL/SDL.h>
     #endif
+
+    #ifdef USE_SDL1
+        // These macros aren't present in older versions of SDL 1.2.
+        // In those versions, event.button.button will either never
+        // equal these, or it will and scrolling works the same way,
+        // so it's safe to define them ourselves.
+        #ifndef SDL_BUTTON_WHEELUP
+        #define SDL_BUTTON_WHEELUP 4
+        #endif
+        #ifndef SDL_BUTTON_WHEELDOWN
+        #define SDL_BUTTON_WHEELDOWN 5
+        #endif
+    #endif
 #else
     #include <SDL2/SDL.h>
 #endif
-
-// These macros aren't present in older versions of SDL 1.2.
-// In those versions, event.button.button will either never
-// equal these, or it will and scrolling works the same way,
-// so it's safe to define them ourselves.
-#ifndef SDL_BUTTON_WHEELUP
-#define SDL_BUTTON_WHEELUP 4
-#endif
-#ifndef SDL_BUTTON_WHEELDOWN
-#define SDL_BUTTON_WHEELDOWN 5
-#endif
-


### PR DESCRIPTION
Makefile changes:
- SDL library dependencies are determined by running pkg-config now, which is the only proper way to do this.  Systems without pkg-config can manually specify the correct libraries with the SDL1_LIBS or SDL2_LIBS variables.
- We now use the proper GCC flags to handle the dependencies of modified header files, instead of doing a full rebuild on every header change.  Setting the DISABLE_MMD variable will go back to the old behavior, useful for people trying to use compilers that don't support the required flags.

SDL 1.2 changes:
- Added scroll wheel support.