### PR TITLE
Nix Flake support for Nix users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ xcuserdata/
 
 # Clangd
 .clangd
+
+# Nix derivation result outputs
+[Rr]esult

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,19 @@ project(nbcraft)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 
+option(NBC_SYSTEM_STB OFF)
+option(NBC_NIX_BUILD OFF)
+
+if(NBC_NIX_BUILD)
+    if(NOT NBC_SYSTEM_STB)
+        message(SEND_ERROR "Option NBC_NIX_BUILD depends on NBC_SYSTEM_STB, needs to be ON.")
+    endif()
+endif()
+
+if(NBC_SYSTEM_STB)
+    add_compile_definitions(NBC_SYSTEM_STB)
+endif()
+
 # MC_VERSION string is an 7 digit number with 4 components, era, major, minor, and patch.
 # Each component takes 2 digits, except era, which takes 1. Major, minor, and patch are self explanatory,
 # era designates if the version is from alpha, beta, or release. Alpha is 1, beta is 2, and release is 3.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "The ultimate cross-platform mining experience.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = (import nixpkgs { inherit system; });
+          nbcraft = pkgs.callPackage platforms/nix/package.nix { };
+        in
+        {
+          inherit nbcraft;
+          default = nbcraft;
+          devShell = pkgs.mkShell { inputsFrom = [ nbcraft ]; };
+        }
+      );
+    };
+}

--- a/platforms/nix/package.nix
+++ b/platforms/nix/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  fetchFromGitHub,
+  xorg,
+  xorgserver,
+  pkg-config,
+  SDL2,
+  openal,
+  libGLX,
+  libvorbis,
+  stb,
+  clang,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nbcraft";
+  version = "0.3.3";
+
+  src = ../../.;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    clang
+  ];
+  buildInputs = [
+    SDL2
+    openal
+    libGLX
+    libvorbis
+    # Build a newer version of stb
+    (stb.overrideAttrs (previousAttrs: {
+      version = "0-unstable-2026-04-15";
+      src = fetchFromGitHub {
+        owner = "nothings";
+        repo = "stb";
+        rev = "31c1ad37456438565541f4919958214b6e762fb4";
+        hash = "sha256-m2yNUlA37hDkKQVrQ+R8nufHfW/cXLnMo+n1X1Cyun0=";
+      };
+    }))
+  ];
+
+  cmakeFlags = [
+    "-D NBC_SYSTEM_STB=ON" # Required by NBC_NIX_BUILD
+    "-D NBC_NIX_BUILD=ON"
+    "-D CMAKE_C_COMPILER=${clang}/bin/clang"
+    "-D CMAKE_CXX_COMPILER=${clang}/bin/clang++"
+    "-D CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=${stb}/include/stb/"
+    "-D STB_INCLUDE=${stb}/include/stb/"
+    "-D STB_VORBIS_SOURCE=${stb}/include/stb/stb_vorbis.c"
+  ];
+})

--- a/platforms/sdl/base/AppPlatform_sdl.cpp
+++ b/platforms/sdl/base/AppPlatform_sdl.cpp
@@ -10,8 +10,13 @@
 #include <emscripten.h>
 #endif
 
-#include "thirdparty/stb_image/include/stb_image.h"
-#include "thirdparty/stb_image/include/stb_image_write.h"
+#if NBC_SYSTEM_STB
+    #include <stb_image.h>
+	#include <stb_image_write.h>
+#else
+	#include "thirdparty/stb_image/include/stb_image.h"
+	#include "thirdparty/stb_image/include/stb_image_write.h"
+#endif
 
 #if MCE_GFX_API_OGL
 // needed for screenshots

--- a/platforms/sdl/sdl1/CMakeLists.txt
+++ b/platforms/sdl/sdl1/CMakeLists.txt
@@ -60,3 +60,5 @@ if(XENON) # Xbox 360 (libXenon)
         COMMENT "Converting to elf32 and stripping..."
     )
 endif()
+
+install(TARGETS nbcraft DESTINATION bin)

--- a/platforms/sdl/sdl2/CMakeLists.txt
+++ b/platforms/sdl/sdl2/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ANDROID)
     set_target_properties(nbcraft PROPERTIES OUTPUT_NAME main)
 else()
     add_executable(nbcraft ${SOURCES})
+    install(TARGETS nbcraft DESTINATION bin)
 endif()
 
 # Core

--- a/platforms/windows/AppPlatform_win32.cpp
+++ b/platforms/windows/AppPlatform_win32.cpp
@@ -25,8 +25,13 @@
 #include "thirdparty/GL/GL.hpp"
 #endif
 
-#include "thirdparty/stb_image/include/stb_image.h"
-#include "thirdparty/stb_image/include/stb_image_write.h"
+#if NBC_SYSTEM_STB
+    #include <stb_image.h>
+	#include <stb_image_write.h>
+#else
+	#include "thirdparty/stb_image/include/stb_image.h"
+	#include "thirdparty/stb_image/include/stb_image_write.h"
+#endif
 
 // Macros are cursed
 #define _STR(x) #x

--- a/platforms/windows/CMakeLists.txt
+++ b/platforms/windows/CMakeLists.txt
@@ -46,3 +46,5 @@ target_link_libraries(nbcraft nbcraft-core)
 
 # stb_image (If Needed)
 target_link_libraries(nbcraft stb_image)
+
+install(TARGETS nbcraft DESTINATION bin)

--- a/source/client/app/AppPlatform.cpp
+++ b/source/client/app/AppPlatform.cpp
@@ -9,7 +9,11 @@
 #include <fstream>
 #include <time.h>
 
-#include "thirdparty/stb_image/include/stb_image.h"
+#if NBC_SYSTEM_STB
+    #include <stb_image.h>
+#else
+	#include "thirdparty/stb_image/include/stb_image.h"
+#endif
 
 #include "AppPlatform.hpp"
 #include "common/Logger.hpp"

--- a/source/client/sound/SoundData.cpp
+++ b/source/client/sound/SoundData.cpp
@@ -9,7 +9,12 @@
 #include <stdlib.h>
 
 #define STB_VORBIS_HEADER_ONLY
-#include "thirdparty/stb_image/include/stb_vorbis.c"
+
+#if NBC_SYSTEM_STB
+    #include <stb_vorbis.c>
+#else
+    #include "thirdparty/stb_image/include/stb_vorbis.c"
+#endif
 
 #include "SoundData.hpp"
 

--- a/source/client/sound/SoundStream.hpp
+++ b/source/client/sound/SoundStream.hpp
@@ -3,7 +3,12 @@
 #include <string>
 
 #define STB_VORBIS_HEADER_ONLY
-#include "thirdparty/stb_image/include/stb_vorbis.c"
+
+#if NBC_SYSTEM_STB
+    #include <stb_vorbis.c>
+#else
+    #include "thirdparty/stb_image/include/stb_vorbis.c"
+#endif
 
 #include "compat/LegacyCPP.hpp"
 #include "client/sound/SoundData.hpp"

--- a/thirdparty/glm/CMakeLists.txt
+++ b/thirdparty/glm/CMakeLists.txt
@@ -36,6 +36,8 @@ if(GLM_TEST_ENABLE)
 		${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
 		${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
 		${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER})
+
+	install(TARGETS ${NAME} DESTINATION bin)
 endif(GLM_TEST_ENABLE)
 
 #add_library(glm STATIC glm.cpp)

--- a/thirdparty/stb_image/CMakeLists.txt
+++ b/thirdparty/stb_image/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.16.0)
 project(stb_image)
 
+set(STB_IMAGE_SOURCE src/stb_image_impl.c)
+
+if(NOT NBC_NIX_BUILD)
+    set(STB_VORBIS_SOURCE include/stb_vorbis.c)
+    set(STB_INCLUDE include)
+endif()
+
 # Build
-add_library(stb_image STATIC src/stb_image_impl.c)
-target_include_directories(stb_image PUBLIC include)
-add_library(stb_vorbis STATIC include/stb_vorbis.c)
-target_include_directories(stb_vorbis PUBLIC include)
+add_library(stb_image STATIC ${STB_IMAGE_SOURCE})
+target_include_directories(stb_image PUBLIC ${STB_INCLUDE})
+add_library(stb_vorbis STATIC ${STB_VORBIS_SOURCE})
+target_include_directories(stb_vorbis PUBLIC ${STB_INCLUDE})


### PR DESCRIPTION
This pull request adds a Nix Flake, providing the `nbcraft` package for easy installation through the Nix package manager, Home Manager, and NixOS. This package consequently also provides reproducible builds, as such Nix users can also test, debug, and inspect NBcraft in a common environment. I believe this change improves the availability of NBcraft a lot.

This pull request also changes the CMake build process, adding an installation target.
The `stb` source and include paths are also now variables so that they can be pointed to Nix's `stb` files during the build process.

```cmake
set(STB_IMAGE_SOURCE src/stb_image_impl.c)

if(NOT NIX_BUILD)
    set(STB_VORBIS_SOURCE include/stb_vorbis.c)
    set(STB_INCLUDE include)
endif()
```

Lastly, some `include`s have been change in order to support system-wide `stb` installations, such as through Nix. This does not conflict with the existing submodule-based approach, which remains the default. Nix Flakes unfortunately don't properly support Git submodules, making this change necessary.