### PR TITLE
Cleanup + bugfix

### DIFF
--- a/source/client/app/Minecraft.cpp
+++ b/source/client/app/Minecraft.cpp
@@ -1054,13 +1054,6 @@ void Minecraft::update()
 
 	renderContext.beginRender();
 
-	if (!m_bPreparingLevel)
-	{
-		GameMode* pGameMode = getLocalPlayerGameMode();
-		if (pGameMode)
-			pGameMode->render(m_timer.m_renderTicks);
-	}
-
 	m_pGameRenderer->render(m_timer);
 
 	renderContext.endRender();

--- a/source/client/gui/Gui.cpp
+++ b/source/client/gui/Gui.cpp
@@ -163,7 +163,7 @@ void Gui::inventoryUpdated()
 	field_A3C = true;
 }
 
-void Gui::render(float f, bool bHaveScreen, int mouseX, int mouseY)
+void Gui::render(float f, bool bHaveScreen)
 {
 	Minecraft& mc = *m_pMinecraft;
 	GameRenderer& renderer = *mc.m_pGameRenderer;

--- a/source/client/gui/Gui.hpp
+++ b/source/client/gui/Gui.hpp
@@ -58,7 +58,7 @@ public:
 	void addMessage(const std::string& str);
 	void inventoryUpdated();
 	void setNowPlaying(const std::string& str);
-	void render(float f, bool bHaveScreen, int mouseX, int mouseY);
+	void render(float f, bool bHaveScreen);
 	void tick();
 	void renderSlot(int slot, int x, int y, float f);
 	void renderSlotOverlay(int slot, int x, int y, float f);

--- a/source/client/renderer/GameRenderer.cpp
+++ b/source/client/renderer/GameRenderer.cpp
@@ -540,8 +540,13 @@ void GameRenderer::renderLevel(float f)
 		}
 	}
 
-	if (!m_pMinecraft->m_bIsGamePaused)
+	if (!m_pMinecraft->isGamePaused())
 		pick(f);
+
+	// render the GameMode stuff (tile destruction) after the new Tile has been picked
+	GameMode* pGameMode = m_pMinecraft->getLocalPlayerGameMode();
+	if (pGameMode)
+		pGameMode->render(f);
 
 	const Entity& camera = *pCamera;
 	Vec3 camPos = camera.m_posPrev + (camera.m_pos - camera.m_posPrev) * f;
@@ -589,23 +594,9 @@ void GameRenderer::renderLevel(float f)
 
 void GameRenderer::renderFramedItems(const Vec3& camPos, LevelRenderer& levelRenderer, const Entity& camera, float f, ParticleEngine& particleEngine, float i)
 {
-	/*
-	if (m_pMinecraft->getOptions()->m_viewDistance <= 1)
-	{
-#ifndef ORIGINAL_CODE
-			// @NOTE: For whatever reason, Minecraft doesn't enable GL_FOG right away.
-			// It appears to work in bluestacks for whatever reason though...
-			Fog::enable();
-#endif
-			setupFog(-1);
-			pLR->renderSky(f);
-		}
-		*/
-
-	mce::RenderContext& renderContext = mce::RenderContextImmediate::get();
-
 	if (m_pMinecraft->getOptions()->m_ambientOcclusion.get())
 	{
+		mce::RenderContext& renderContext = mce::RenderContextImmediate::get();
 		renderContext.setShadeMode(mce::SHADE_MODE_SMOOTH);
 	}
 
@@ -620,14 +611,16 @@ void GameRenderer::renderFramedItems(const Vec3& camPos, LevelRenderer& levelRen
 
 	if (m_zoom == 1.0f)
 	{
-		if (camera.isPlayer() && m_pMinecraft->m_hitResult.m_hitType != HitResult::NONE)
+		const HitResult& hr = m_pMinecraft->m_hitResult;
+
+		if (camera.isPlayer() && hr.isHit())
 		{
-			levelRenderer.renderCracks(camera, m_pMinecraft->m_hitResult, 0, nullptr, f);
+			levelRenderer.renderCracks(camera, hr, 0, nullptr, f);
 
 			if (m_pMinecraft->getOptions()->m_blockOutlines.get())
-				levelRenderer.renderHitOutline(camera, m_pMinecraft->m_hitResult, 0, nullptr, f);
+				levelRenderer.renderHitOutline(camera, hr, 0, nullptr, f);
 			else
-				levelRenderer.renderHitSelect(camera, m_pMinecraft->m_hitResult, 0, nullptr, f);
+				levelRenderer.renderHitSelect(camera, hr, 0, nullptr, f);
 		}
 
 		_renderItemInHand(f, i);
@@ -731,15 +724,17 @@ void GameRenderer::render(const Timer& timer)
 		if (m_keepPic < 0)
 		{
 			renderLevel(timer.m_renderTicks);
+
 			currentShaderColor = Color::WHITE;
 			currentShaderDarkColor = Color::WHITE;
+
 			if (m_pMinecraft->getOptions()->m_hideGui.get())
 			{
 				if (!m_pMinecraft->m_pScreen)
 					return;
 			}
 
-			m_pMinecraft->m_pGui->render(timer.m_renderTicks, m_pMinecraft->m_pScreen != nullptr, mouseX, mouseY);
+			m_pMinecraft->m_pGui->render(timer.m_renderTicks, m_pMinecraft->m_pScreen != nullptr);
 		}
 	}
 	else
@@ -1064,19 +1059,16 @@ void GameRenderer::pick(float f)
 	else
 	{
 		// easy case: pick from the middle of the screen
-		HitResult hrMob = mob.pick(dist, f);
-		mchr = hrMob;
+		mchr = mob.pick(dist, f);
 	}
 
 	Vec3 mobPos = mob.getInterpolatedPosition(f);
 
-	if (mchr.m_hitType != HitResult::NONE)
+	if (mchr.isHit())
 		dist = mchr.m_hitPos.distanceTo(mobPos);
 
 	float maxEntityDist = m_pMinecraft->getLocalPlayerGameMode()->getEntityReachDistance();
-	/*if (m_pMinecraft->m_pGameMode->isCreativeType())
-		dist = 7.0f;
-	else */if (dist > maxEntityDist)
+	if (dist > maxEntityDist)
 		dist = maxEntityDist;
 
 	Vec3 view = mob.getViewVector(f);

--- a/source/client/renderer/LevelRenderer.cpp
+++ b/source/client/renderer/LevelRenderer.cpp
@@ -1289,19 +1289,15 @@ void LevelRenderer::renderCracks(const Entity& camera, const HitResult& hr, int 
 
 			MatrixStack::Ref matrix = MatrixStack::World.push();
 
-			Tile* pTile = nullptr;
-			TileID tile = tileSource.getTile(hr.m_tilePos);
-			if (tile > 0)
-				pTile = Tile::tiles[tile];
+			TileID tileId = tileSource.getTile(hr.m_tilePos);
+			Tile* pTile = tileId > 0 ? Tile::tiles[tileId] : nullptr;
 
-			float px = camera.m_posPrev.x + (camera.m_pos.x - camera.m_posPrev.x) * a;
-			float py = camera.m_posPrev.y + (camera.m_pos.y - camera.m_posPrev.y) * a;
-			float pz = camera.m_posPrev.z + (camera.m_pos.z - camera.m_posPrev.z) * a;
+			Vec3 p = camera.m_posPrev + (camera.m_pos - camera.m_posPrev) * a;
 
 			Tesselator& t = Tesselator::instance;
 
 			t.begin(12);
-			t.setOffset(-px, -py, -pz);
+			t.setOffset(-p);
 			t.noColor();
 			if (!pTile)
 				pTile = Tile::rock;

--- a/source/world/gamemode/CreativeMode.cpp
+++ b/source/world/gamemode/CreativeMode.cpp
@@ -10,10 +10,6 @@
 #include "client/app/Minecraft.hpp"
 
 CreativeMode::CreativeMode(Minecraft* pMC, Level& level) : GameMode(pMC, level),
-	m_destroyingPos(-1, -1, -1),
-	m_destroyProgress(0.0f),
-	m_lastDestroyProgress(0.0f),
-	m_destroyTicks(0),
 	m_destroyCooldown(0)
 {
 }
@@ -48,7 +44,6 @@ bool CreativeMode::continueDestroyBlock(Player& player, const TilePos& pos, Faci
 
 void CreativeMode::stopDestroyBlock()
 {
-	m_destroyProgress = 0.0f;
 	m_destroyCooldown = 0;
 }
 
@@ -59,23 +54,7 @@ void CreativeMode::tick()
 
 void CreativeMode::render(float f)
 {
-	if (m_destroyProgress <= 0.0f)
-	{
-		m_pMinecraft->m_pGui->m_progress = 0.0f;
-		m_pMinecraft->m_pGui->m_lastDestroyProgress = 0.0f;
-		m_pMinecraft->m_pGui->m_destroyProgress = 0.0f;
-		m_pMinecraft->m_pLevelRenderer->m_destroyProgress = 0.0f;
-	}
-	else
-	{
-		float x = m_lastDestroyProgress + (m_destroyProgress - m_lastDestroyProgress) * f;
-		m_pMinecraft->m_pGui->m_progress = x;
-		m_pMinecraft->m_pGui->m_lastDestroyProgress = m_lastDestroyProgress;
-		m_pMinecraft->m_pGui->m_destroyProgress = m_destroyProgress;
-		m_pMinecraft->m_pLevelRenderer->m_destroyProgress = x;
-	}
-
-	m_lastDestroyProgress = m_destroyProgress;
+	GameMode::render(f);
 }
 
 void CreativeMode::initPlayer(Player& p)

--- a/source/world/gamemode/CreativeMode.hpp
+++ b/source/world/gamemode/CreativeMode.hpp
@@ -25,13 +25,9 @@ public:
 	void stopDestroyBlock() override;
 	void tick() override;
 	void render(float f) override;
-	float getDestroyModifier() const override { return 8.0; }
+	float getDestroyModifier() const override { return 8.0f; }
 
 public:
-	TilePos m_destroyingPos;
-	float m_destroyProgress;
-	float m_lastDestroyProgress;
-	int m_destroyTicks;
 	int m_destroyCooldown;
 };
 

--- a/source/world/gamemode/GameMode.cpp
+++ b/source/world/gamemode/GameMode.cpp
@@ -14,7 +14,7 @@
 GameMode::GameMode(Minecraft* pMinecraft, Level& level) :
 	_level(level),
 	m_pMinecraft(pMinecraft),
-	m_bInstaBuild(0)
+	m_bInstaBuild(false)
 {
 }
 
@@ -83,6 +83,7 @@ void GameMode::render(float f)
 
 float GameMode::getBlockReachDistance() const
 {
+	// @PARITY
 	/* Logic from Pocket Edition 0.12.1
 	if ( *inputMode == 1 )
 		return 5.7f;

--- a/source/world/gamemode/GameMode.hpp
+++ b/source/world/gamemode/GameMode.hpp
@@ -50,5 +50,5 @@ public:
 
 public:
 	Minecraft* m_pMinecraft;
-	uint8_t m_bInstaBuild;
+	bool m_bInstaBuild;
 };

--- a/source/world/gamemode/SurvivalMode.cpp
+++ b/source/world/gamemode/SurvivalMode.cpp
@@ -21,6 +21,13 @@ SurvivalMode::SurvivalMode(Minecraft* pMC, Level& level) : GameMode(pMC, level),
 {
 }
 
+void SurvivalMode::_resetDestruction()
+{
+	m_destroyProgress = 0.0f;
+	m_lastDestroyProgress = 0.0f;
+	m_destroyTicks = 0;
+}
+
 void SurvivalMode::initPlayer(Player& p)
 {
 	p.m_rot.yaw = -180.0f;
@@ -70,12 +77,13 @@ bool SurvivalMode::destroyBlock(Player& player, const TilePos& pos, Facing::Name
 {
 	TileSource& source = player.getTileSource();
 
-	TileID tile = source.getTile(pos);
-	int    data = source.getData(pos);
+	TileID   tileId = source.getTile(pos);
+	TileData data   = source.getData(pos);
+	Tile*    pTile  = Tile::tiles[tileId];
 
 	bool changed = GameMode::destroyBlock(player, pos, face);
 
-	bool couldDestroy = player.canDestroy(Tile::tiles[tile]);
+	bool couldDestroy = player.canDestroy(pTile);
 	ItemStack& item = player.getSelectedItem();
 	if (!item.isEmpty())
 	{
@@ -93,10 +101,10 @@ bool SurvivalMode::destroyBlock(Player& player, const TilePos& pos, Facing::Name
 		ItemStack tileItem(tile, 1, data);
 		if (tile == TILE_GRASS || !player.m_pInventory->hasUnlimitedResource(tileItem))
 		{
-			Tile::tiles[tile]->playerDestroy(player, pos, data);
+			pTile->playerDestroy(player, pos, data);
 		}
 #else
-		Tile::tiles[tile]->playerDestroy(player, pos, data);
+		pTile->playerDestroy(player, pos, data);
 #endif
 	}
 
@@ -113,9 +121,7 @@ bool SurvivalMode::continueDestroyBlock(Player& player, const TilePos& pos, Faci
 
 	if (m_destroyingPos != pos)
 	{
-		m_destroyProgress     = 0.0f;
-		m_lastDestroyProgress = 0.0f;
-		m_destroyTicks = 0;
+		_resetDestruction();
 		m_destroyingPos = pos;
 		return false;
 	}
@@ -131,7 +137,7 @@ bool SurvivalMode::continueDestroyBlock(Player& player, const TilePos& pos, Faci
 	m_destroyProgress += getDestroyModifier() * destroyProgress;
 	m_destroyTicks++;
 
-	if ((m_destroyTicks & 3) == 1)
+	if ((m_destroyTicks & 3) == 1) // m_destroyTicks % 4.0f == 0.0f
 	{
 		_level.playSound(pos + 0.5f, "step." + pTile->m_pSound->name,
 			0.125f * (1.0f + pTile->m_pSound->volume), 0.5f * pTile->m_pSound->pitch);
@@ -139,10 +145,8 @@ bool SurvivalMode::continueDestroyBlock(Player& player, const TilePos& pos, Faci
 
 	if (m_destroyProgress >= 1.0f)
 	{
-		m_destroyTicks    = 0;
+		_resetDestruction();
 		m_destroyCooldown = 5;
-		m_destroyProgress     = 0.0f;
-		m_lastDestroyProgress = 0.0f;
 
 		// @PARITY: This is in MultiPlayerGameMode on Java, but we aren't equipped to move to that at the moment. Also, is not sent on PE.
 #if NETWORK_PROTOCOL_VERSION >= 6
@@ -165,29 +169,38 @@ void SurvivalMode::stopDestroyBlock()
 
 void SurvivalMode::tick()
 {
+	m_lastDestroyProgress = m_destroyProgress;
 	//m_pMinecraft->m_pSoundEngine->playMusicTick(); // also on MultiPlayerGameMode
 	GameMode::tick();
 }
 
 void SurvivalMode::render(float f)
 {
+	const HitResult& hr = m_pMinecraft->m_hitResult;
+	Gui& gui = *m_pMinecraft->m_pGui;
+	LevelRenderer& levelRenderer = *m_pMinecraft->m_pLevelRenderer;
+
+	// @HACK: fix destory progress carrying over for the first few frames of another Tile
+	if (m_destroyProgress > 0.0f && hr.isHit() && m_destroyingPos != hr.m_tilePos)
+	{
+		_resetDestruction();
+	}
+
 	if (m_destroyProgress <= 0.0f)
 	{
-		m_pMinecraft->m_pGui->m_progress = 0.0f;
-		m_pMinecraft->m_pGui->m_lastDestroyProgress = 0.0f;
-		m_pMinecraft->m_pGui->m_destroyProgress = 0.0f;
-		m_pMinecraft->m_pLevelRenderer->m_destroyProgress = 0.0f;
+		gui.m_progress = 0.0f;
+		gui.m_lastDestroyProgress = 0.0f;
+		gui.m_destroyProgress = 0.0f;
+		levelRenderer.m_destroyProgress = 0.0f;
 	}
 	else
 	{
 		float dp = m_lastDestroyProgress + (m_destroyProgress - m_lastDestroyProgress) * f;
-		m_pMinecraft->m_pGui->m_progress = dp;
-		m_pMinecraft->m_pGui->m_lastDestroyProgress = m_lastDestroyProgress;
-		m_pMinecraft->m_pGui->m_destroyProgress = m_destroyProgress;
-		m_pMinecraft->m_pLevelRenderer->m_destroyProgress = dp;
+		gui.m_progress = dp;
+		gui.m_lastDestroyProgress = m_lastDestroyProgress;
+		gui.m_destroyProgress = m_destroyProgress;
+		levelRenderer.m_destroyProgress = dp;
 	}
-
-	m_lastDestroyProgress = m_destroyProgress;
 }
 
 bool SurvivalMode::useItemOn(Player& player, ItemStack& item, const TilePos& pos, Facing::Name face)

--- a/source/world/gamemode/SurvivalMode.hpp
+++ b/source/world/gamemode/SurvivalMode.hpp
@@ -15,6 +15,10 @@ class SurvivalMode : public GameMode
 public:
 	SurvivalMode(Minecraft*, Level&);
 
+private:
+	void _resetDestruction();
+
+public:
 	bool startDestroyBlock(Player& player, const TilePos& pos, Facing::Name face) override;
 	bool destroyBlock(Player& player, const TilePos& pos, Facing::Name face) override;
 	bool continueDestroyBlock(Player& player, const TilePos& pos, Facing::Name face) override;
@@ -28,7 +32,7 @@ public:
 	bool isSurvivalType() const override { return true; }
 	void initPlayer(Player&) override;
 	bool canHurtPlayer() override;
-	float getDestroyModifier() const override { return 1.0; }
+	float getDestroyModifier() const override { return 1.0f; }
 
 public:
 	TilePos m_destroyingPos;

--- a/source/world/phys/HitResult.cpp
+++ b/source/world/phys/HitResult.cpp
@@ -11,7 +11,6 @@
 void HitResult::_init()
 {
 	m_hitType = NONE;
-	m_tilePos = TilePos();
 
 	m_hitSide = Facing::DOWN;
 


### PR DESCRIPTION
Bugfixes:
* After breaking a block, the full breaking animation no longer shows on the next highlighted block for a few frames (Closes #474)